### PR TITLE
Update 1_managed-rag-kb-retrieve-generate-api.ipynb by haochu

### DIFF
--- a/knowledge-bases/1_managed-rag-kb-retrieve-generate-api.ipynb
+++ b/knowledge-bases/1_managed-rag-kb-retrieve-generate-api.ipynb
@@ -94,6 +94,7 @@
     "                              config=bedrock_config)\n",
     "\n",
     "model_id = \"anthropic.claude-instant-v1\" # try with both claude instant as well as claude-v2. for claude v2 - \"anthropic.claude-v2\"\n",
+    "region_id = \"<region>\" # replace it with the region you're running sagemaker notebook\n",
     "kb_id = \"<knowledge_base_id>\" # replace it with the Knowledge base id.\n"
    ]
   },
@@ -113,8 +114,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def retrieveAndGenerate(input, kbId, sessionId=None, model_id = \"anthropic.claude-instant-v1\"):\n",
-    "    model_arn = f'arn:aws:bedrock:us-east-1::foundation-model/{model_id}'\n",
+    "def retrieveAndGenerate(input, kbId, sessionId=None, model_id = \"anthropic.claude-instant-v1\", region_id = \"us-east-1\"):\n",
+    "    model_arn = f'arn:aws:bedrock:{region_id}::foundation-model/{model_id}'\n",
     "    if sessionId:\n",
     "        return bedrock_agent_client.retrieve_and_generate(\n",
     "            input={\n",
@@ -153,7 +154,7 @@
    "outputs": [],
    "source": [
     "query = \"What is Amazon's doing in the field of generative AI?\"\n",
-    "response = retrieveAndGenerate(query, kb_id,model_id=model_id)\n",
+    "response = retrieveAndGenerate(query, kb_id,model_id=model_id,region_id=region_id)\n",
     "generated_text = response['output']['text']\n",
     "pp.pprint(generated_text)"
    ]


### PR DESCRIPTION
Added Region_id into retrieveAndGenerate function, allowing user to define which region the sagemaker is in.  This will avoid validation error due to model arn not in service region, which occurs when sagemaker and bedrock model is not in the same region

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
