### PR TITLE
Repair broken sql-query-generator example

### DIFF
--- a/rag-solutions/sql-query-generator/northwind_ddl.sql
+++ b/rag-solutions/sql-query-generator/northwind_ddl.sql
@@ -1,0 +1,251 @@
+
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SET check_function_bodies = false;
+SET client_min_messages = warning;
+
+
+
+SET default_tablespace = '';
+
+SET default_with_oids = false;
+
+
+---
+--- drop tables
+---
+
+
+DROP TABLE IF EXISTS customer_customer_demo;
+DROP TABLE IF EXISTS customer_demographics;
+DROP TABLE IF EXISTS employee_territories;
+DROP TABLE IF EXISTS order_details;
+DROP TABLE IF EXISTS orders;
+DROP TABLE IF EXISTS customers;
+DROP TABLE IF EXISTS products;
+DROP TABLE IF EXISTS shippers;
+DROP TABLE IF EXISTS suppliers;
+DROP TABLE IF EXISTS territories;
+DROP TABLE IF EXISTS us_states;
+DROP TABLE IF EXISTS categories;
+DROP TABLE IF EXISTS region;
+DROP TABLE IF EXISTS employees;
+
+--
+-- Name: categories; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE TABLE categories (
+    category_id smallint NOT NULL PRIMARY KEY,
+    category_name character varying(15) NOT NULL,
+    description text,
+    picture bytea
+);
+
+
+--
+-- Name: customer_demographics; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE TABLE customer_demographics (
+    customer_type_id bpchar NOT NULL PRIMARY KEY,
+    customer_desc text
+);
+
+
+--
+-- Name: customers; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE TABLE customers (
+    customer_id bpchar NOT NULL PRIMARY KEY,
+    company_name character varying(40) NOT NULL,
+    contact_name character varying(30),
+    contact_title character varying(30),
+    address character varying(60),
+    city character varying(15),
+    region character varying(15),
+    postal_code character varying(10),
+    country character varying(15),
+    phone character varying(24),
+    fax character varying(24)
+);
+
+--
+-- Name: customer_customer_demo; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE TABLE customer_customer_demo (
+    customer_id bpchar NOT NULL,
+    customer_type_id bpchar NOT NULL,
+    PRIMARY KEY (customer_id, customer_type_id),
+    FOREIGN KEY (customer_type_id) REFERENCES customer_demographics,
+    FOREIGN KEY (customer_id) REFERENCES customers
+);
+
+--
+-- Name: employees; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE TABLE employees (
+    employee_id smallint NOT NULL PRIMARY KEY,
+    last_name character varying(20) NOT NULL,
+    first_name character varying(10) NOT NULL,
+    title character varying(30),
+    title_of_courtesy character varying(25),
+    birth_date date,
+    hire_date date,
+    address character varying(60),
+    city character varying(15),
+    region character varying(15),
+    postal_code character varying(10),
+    country character varying(15),
+    home_phone character varying(24),
+    extension character varying(4),
+    photo bytea,
+    notes text,
+    reports_to smallint,
+    photo_path character varying(255),
+	FOREIGN KEY (reports_to) REFERENCES employees
+);
+
+
+--
+-- Name: suppliers; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE TABLE suppliers (
+    supplier_id smallint NOT NULL PRIMARY KEY,
+    company_name character varying(40) NOT NULL,
+    contact_name character varying(30),
+    contact_title character varying(30),
+    address character varying(60),
+    city character varying(15),
+    region character varying(15),
+    postal_code character varying(10),
+    country character varying(15),
+    phone character varying(24),
+    fax character varying(24),
+    homepage text
+);
+
+
+--
+-- Name: products; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE TABLE products (
+    product_id smallint NOT NULL PRIMARY KEY,
+    product_name character varying(40) NOT NULL,
+    supplier_id smallint,
+    category_id smallint,
+    quantity_per_unit character varying(20),
+    unit_price real,
+    units_in_stock smallint,
+    units_on_order smallint,
+    reorder_level smallint,
+    discontinued integer NOT NULL,
+	FOREIGN KEY (category_id) REFERENCES categories,
+	FOREIGN KEY (supplier_id) REFERENCES suppliers
+);
+
+
+--
+-- Name: region; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE TABLE region (
+    region_id smallint NOT NULL PRIMARY KEY,
+    region_description bpchar NOT NULL
+);
+
+
+--
+-- Name: shippers; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE TABLE shippers (
+    shipper_id smallint NOT NULL PRIMARY KEY,
+    company_name character varying(40) NOT NULL,
+    phone character varying(24)
+);
+
+
+--
+-- Name: orders; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE TABLE orders (
+    order_id smallint NOT NULL PRIMARY KEY,
+    customer_id bpchar,
+    employee_id smallint,
+    order_date date,
+    required_date date,
+    shipped_date date,
+    ship_via smallint,
+    freight real,
+    ship_name character varying(40),
+    ship_address character varying(60),
+    ship_city character varying(15),
+    ship_region character varying(15),
+    ship_postal_code character varying(10),
+    ship_country character varying(15),
+    FOREIGN KEY (customer_id) REFERENCES customers,
+    FOREIGN KEY (employee_id) REFERENCES employees,
+    FOREIGN KEY (ship_via) REFERENCES shippers
+);
+
+
+--
+-- Name: territories; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE TABLE territories (
+    territory_id character varying(20) NOT NULL PRIMARY KEY,
+    territory_description bpchar NOT NULL,
+    region_id smallint NOT NULL,
+	FOREIGN KEY (region_id) REFERENCES region
+);
+
+
+--
+-- Name: employee_territories; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE TABLE employee_territories (
+    employee_id smallint NOT NULL,
+    territory_id character varying(20) NOT NULL,
+    PRIMARY KEY (employee_id, territory_id),
+    FOREIGN KEY (territory_id) REFERENCES territories,
+    FOREIGN KEY (employee_id) REFERENCES employees
+);
+
+
+--
+-- Name: order_details; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE TABLE order_details (
+    order_id smallint NOT NULL,
+    product_id smallint NOT NULL,
+    unit_price real NOT NULL,
+    quantity smallint NOT NULL,
+    discount real NOT NULL,
+    PRIMARY KEY (order_id, product_id),
+    FOREIGN KEY (product_id) REFERENCES products,
+    FOREIGN KEY (order_id) REFERENCES orders
+);
+
+
+--
+-- Name: us_states; Type: TABLE; Schema: public; Owner: -; Tablespace: 
+--
+
+CREATE TABLE us_states (
+    state_id smallint NOT NULL PRIMARY KEY,
+    state_name character varying(100),
+    state_abbr character varying(2),
+    state_region character varying(50)
+);

--- a/rag-solutions/sql-query-generator/requirements.txt
+++ b/rag-solutions/sql-query-generator/requirements.txt
@@ -3,4 +3,4 @@ boto3
 langchain==0.0.330
 streamlit
 pandas
-chromadb=0.4.14
+chromadb==0.4.14

--- a/rag-solutions/sql-query-generator/sql_query_chain.py
+++ b/rag-solutions/sql-query-generator/sql_query_chain.py
@@ -19,6 +19,7 @@ bedrock_embedding = BedrockEmbeddings(
 
 anthropic_claude_llm = Bedrock(
     credentials_profile_name=credentials_profile_name,
+    region_name=region_name,
     model_id="anthropic.claude-v2"
 )
 


### PR DESCRIPTION
*Issue #, if available:*  #76

*Description of changes:*

This PR fixes the following issues in the sql-query-generator example

### pip install errors

Running `pip3 install -r requirements.txt -U` errors out with 

```text
ERROR: Invalid requirement: 'chromadb=0.4.14' (from line 6 of requirements.txt)
Hint: = is not a valid operator. Did you mean == ?
```

### Missing 'northwind_ddl.sql'

Error message in streamlit UI: `RuntimeError: Error loading northwind_ddl.sql`

### Missing region in langchain.llms.Bedrock use

Streamlit UI error:

```
  ValueError: Error raised by bedrock service: An error occurred (AccessDeniedException) when calling the InvokeModel operation: You don't have access to the model with the specified model ID.
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
