### PR TITLE
Adding script for fine-tuning Amazon Titan model on Bedrock

### DIFF
--- a/bedrock-fine-tuning/fineTuning_titan_using_bedrock.ipynb
+++ b/bedrock-fine-tuning/fineTuning_titan_using_bedrock.ipynb
@@ -1,0 +1,333 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Fine-tune Amazon Titan model in Bedrock for summarization task"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Import libraries"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install --upgrade sagemaker datasets"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prepare the data in Bedrock required format"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "from datasets import load_dataset\n",
+    "\n",
+    "# Here we are using the Dolly dataset for fine-tuning the titan model for summarization task\n",
+    "dolly_dataset = load_dataset(\"databricks/databricks-dolly-15k\", split=\"train\")\n",
+    "\n",
+    "# Filter the dataset to include only summarization examples\n",
+    "summarization_dataset = dolly_dataset.filter(lambda example: example[\"category\"] == \"summarization\")\n",
+    "summarization_dataset = summarization_dataset.remove_columns(\"category\")\n",
+    "\n",
+    "# Create a new DataFrame with Bedrock supported format\n",
+    "modified_df = summarization_dataset.map(\n",
+    "    lambda example: {\"prompt\": f\"{example['instruction']} {example['context']}\",\n",
+    "                     \"completion\": example[\"response\"]}\n",
+    ")\n",
+    "\n",
+    "# Set max length to support Bedrock Customization Max token Length Quota\n",
+    "max_length_per_row = 18000\n",
+    "\n",
+    "# Set max length to support Bedrock Customization Max token Length Quota\n",
+    "max_row_count = 9000\n",
+    "\n",
+    "# Define a function to check if the total length of prompt and completion is within the specified max_length\n",
+    "def within_length(example):\n",
+    "    return len(example['prompt'] + example['completion']) <= max_length_per_row\n",
+    "\n",
+    "# Filter the DataFrame to include only examples within the specified max length\n",
+    "modified_df = modified_df.filter(within_length)\n",
+    "\n",
+    "num_rows = len(modified_df)\n",
+    "print(f\"Number of rows: {num_rows}\")\n",
+    "\n",
+    "\n",
+    "# Take the maximum supported dataset size\n",
+    "if num_rows > max_row_count:\n",
+    "    modified_df = modified_df.select(range(max_row_count)) \n",
+    "\n",
+    "# Remove unnecessary columns\n",
+    "modified_df = modified_df.remove_columns([\"instruction\", \"context\", \"response\"])\n",
+    "\n",
+    "# Dump the modified DataFrame to a JSON file \"train.jsonl\" in local directory\n",
+    "modified_df.to_json(\"train.jsonl\", orient=\"records\", lines=True)\n",
+    "\n",
+    "# Print the 11th example in the modified DataFrame (since Python uses 0-based indexing)\n",
+    "print(modified_df[10])\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Upload training data to S3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import boto3\n",
+    "from sagemaker import Session\n",
+    "\n",
+    "# Update this to your bucket name and make sure it exists in S3\n",
+    "default_bucket = '<bucket-name>'\n",
+    "\n",
+    "# Create a session using the provided AWS SDK sessions and default bucket\n",
+    "session = Session(boto_session=boto3.session.Session(),\n",
+    "                  sagemaker_client=boto3.client('sagemaker'),\n",
+    "                  sagemaker_runtime_client=boto3.client('runtime.sagemaker'),\n",
+    "                  default_bucket=default_bucket)\n",
+    "\n",
+    "# Create an S3 resource using the AWS SDK\n",
+    "s3 = boto3.resource('s3')\n",
+    "\n",
+    "# Specify the path to the training data on your local machine\n",
+    "train_data_path = 'train.jsonl'\n",
+    "\n",
+    "# Upload the training data to the specified S3 key prefix 'PreProcessed'\n",
+    "s3_train_data = session.upload_data(path=train_data_path, key_prefix='PreProcessed')\n",
+    "\n",
+    "# Print a message indicating the successful upload\n",
+    "print(f\"Uploaded {train_data_path} to {s3_train_data}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create the bedrock training job"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import boto3\n",
+    "import uuid  # Import the 'uuid' module for generating a unique identifier\n",
+    "from sagemaker import get_execution_role\n",
+    "\n",
+    "# Initialize Bedrock client\n",
+    "bedrock = boto3.client(service_name='bedrock')\n",
+    "\n",
+    "# Get the SageMaker execution role\n",
+    "role = get_execution_role()\n",
+    "\n",
+    "# Set parameters\n",
+    "customizationType = \"FINE_TUNING\"\n",
+    "\n",
+    "# Base model to use\n",
+    "basemodelId = 'amazon.titan-text-express-v1'\n",
+    "\n",
+    "# Model ID for provisioned throughput\n",
+    "# https://docs.aws.amazon.com/bedrock/latest/userguide/prov-thru-api.html\n",
+    "baseModelIdentifierForProvisonedThroughput = \"arn:aws:bedrock:us-east-1::foundation-model/amazon.titan-text-express-v1:0:8k\"\n",
+    "job_prefix = \"customTitan\"\n",
+    "\n",
+    "# Update this to a valid roleARn\n",
+    "roleArn = '<ValidRoleARN>'\n",
+    "\n",
+    "# Generate a unique identifier for the job and custom model name\n",
+    "job_uuid = str(uuid.uuid4())[:8]  # Extracting the first 8 characters for brevity\n",
+    "jobName = f\"{job_prefix}-{job_uuid}\"\n",
+    "customModelName = f\"{job_prefix}-{job_uuid}\"\n",
+    "\n",
+    "hyperParameters = {\n",
+    "    \"epochCount\": \"2\",\n",
+    "    \"batchSize\": \"1\",\n",
+    "    \"learningRate\": \"0.00001\",\n",
+    "}\n",
+    "\n",
+    "# Specify the training data configuration using the previously uploaded S3 data\n",
+    "trainingDataConfig = {\"s3Uri\": s3_train_data}\n",
+    "\n",
+    "# Specify the output data configuration for the custom model\n",
+    "outputDataConfig = {\"s3Uri\": f\"s3://{default_bucket}/CustomModel/\"}\n",
+    "\n",
+    "# Create a job for model customization\n",
+    "jobIdentifier = bedrock.create_model_customization_job(\n",
+    "    jobName=jobName,\n",
+    "    customModelName=customModelName,\n",
+    "    roleArn=roleArn,\n",
+    "    baseModelIdentifier=baseModelIdentifierForProvisonedThroughput,\n",
+    "    hyperParameters=hyperParameters,\n",
+    "    trainingDataConfig=trainingDataConfig,\n",
+    "    outputDataConfig=outputDataConfig\n",
+    ")\n",
+    "\n",
+    "# Print the identifier for the created job\n",
+    "print(f\"Model customization job created with identifier: {jobIdentifier}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Monitor the job till the status is shown as \"Completed\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fine_tune_job = bedrock.get_model_customization_job(jobIdentifier=jobIdentifier['jobArn'])\n",
+    "print(fine_tune_job['status'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create provisioned no-commit throughput for the custom model (Only run the following once the status of the above job is shown as \"Completed\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "customModelId=fine_tune_job['outputModelArn']\n",
+    "\n",
+    "\n",
+    "provisionedModelName = f\"{job_prefix}-provisioned-{job_uuid}\"\n",
+    "\n",
+    "# Create the provisioned capacity without passing any commitment option\n",
+    "provisionedModelArn = bedrock.create_provisioned_model_throughput(\n",
+    "    modelUnits=1,\n",
+    "    provisionedModelName=provisionedModelName, \n",
+    "    modelId=customModelId\n",
+    "   )['provisionedModelArn']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Check the provisoned capacity creation status"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get Provisioned model status untill it's completed\n",
+    "provisionedModelStatus = bedrock.get_provisioned_model_throughput(provisionedModelId=provisionedModelArn)\n",
+    "print (provisionedModelStatus['status'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Run inference on the custom provisioned model and the base model via bedrock and observe the difference"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "\n",
+    "# Initialize Bedrock Runtime client in the specified region\n",
+    "bedrockRuntime = boto3.client(service_name='bedrock-runtime', region_name='us-east-1')\n",
+    "\n",
+    "# Sample request body containing text for summarization and parameters for model inference\n",
+    "body = json.dumps({\n",
+    "    \"inputText\": \"Summarize the following:   TOKYO–January 19, 2024–Today, Amazon Web Services (AWS) announced its plans to invest 2.26 trillion yen into its existing cloud infrastructure in Tokyo and Osaka by 2027 to meet growing customer demand for cloud services in Japan. According to the new AWS Economic Impact Study (EIS) for Japan, this planned investment is estimated to contribute 5.57 trillion yen to Japan’s Gross Domestic Product (GDP), and support an estimated average of 30,500 full-time equivalent (FTE) jobs in local Japanese businesses each year. Having already invested 1.51 trillion yen in Japan from 2011 to 2022, AWS’s planned total investment into cloud infrastructure in the country by 2027 will be approximately 3.77 trillion yen. Hundreds of thousands of active customers use the two AWS Regions in Japan to digitally transform (DX) their businesses. AWS opened its first office in Japan in 2009 and launched the AWS Asia Pacific (Tokyo) Region in 2011, and the AWS Asia Pacific (Osaka) Region in 2021. As demand for cloud services to drive the government’s DX agenda grew in Japan, AWS invested 1.51 trillion yen between 2011 and 2022 to construct, connect, operate, and maintain AWS data centers. This is estimated to have contributed 1.46 trillion yen to Japan’s GDP and supported more than 7,100 FTE jobs. These positions, including construction, facility maintenance, engineering, telecommunications, and other jobs within the country’s broader economy, are part of the AWS data center supply chain in Japan.\",\n",
+    "    \"textGenerationConfig\": {\n",
+    "        \"temperature\": 0.01,  \n",
+    "        \"topP\": 0.99,\n",
+    "        \"maxTokenCount\": 300\n",
+    "    }\n",
+    "})\n",
+    "\n",
+    "# Specify content types for request and response\n",
+    "accept = 'application/json'\n",
+    "contentType = 'application/json'\n",
+    "\n",
+    "# Invoke custom model with the provided parameters\n",
+    "response = bedrockRuntime.invoke_model(body=body, modelId=provisionedModelArn, accept=accept, contentType=contentType)\n",
+    "\n",
+    "# Parse and print the output from the custom model\n",
+    "response_body_custom = json.loads(response.get('body').read())\n",
+    "print(\"Custom Model Output:\")\n",
+    "print(response_body_custom['results'][0]['outputText'])\n",
+    "\n",
+    "# Invoke the base model with the same parameters\n",
+    "response = bedrockRuntime.invoke_model(body=body, modelId=basemodelId, accept=accept, contentType=contentType)\n",
+    "\n",
+    "# Parse and print the output from the base model\n",
+    "response_body_base = json.loads(response.get('body').read())\n",
+    "print(\"\\n\")\n",
+    "print(\"Base Model Output:\")\n",
+    "print(response_body_base['results'][0]['outputText'])\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Delete the provisioned capacity and the custom model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Delete the provisioned capacity\n",
+    "bedrock.delete_provisioned_model_throughput(provisionedModelId=provisionedModelArn)\n",
+    "\n",
+    "# Delete the custom model\n",
+    "bedrock.delete_custom_model (modelIdentifier=customModelId)\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adding script for fine-tuning Amazon Titan model on Bedrock. The fine-tuning is targeted towards improving the summarization capability of the Amazon Titan express model. The script also shows the difference in inference behaviour between the custom fine-tune model and the base model.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
