### PR TITLE
add missing library

### DIFF
--- a/multimodal/Titan/titan-multimodal-embeddings/amazon-bedrock-multimodal-oss-searchengine-e2e/titan_mm_embed_search_blog.ipynb
+++ b/multimodal/Titan/titan-multimodal-embeddings/amazon-bedrock-multimodal-oss-searchengine-e2e/titan_mm_embed_search_blog.ipynb
@@ -60,7 +60,8 @@
     "!pip install requests-aws4auth\n",
     "!pip install -U boto3\n",
     "!pip install -U botocore\n",
-    "!pip install -U awscli"
+    "!pip install -U awscli\n",
+    "!pip install -U seaborn"
    ]
   },
   {


### PR DESCRIPTION
*Issue #, if available:*
While running the Titan MM embedding code, I stumbled upon an error at the "1. Setup" step complaining about a missing library: seaborn.

*Description of changes:*
I have added seaborn library in the "Install dependencies" step and the error was fixed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
