### PR TITLE
add text-2-sql-agent-cdk-enhanced

### DIFF
--- a/agents-for-bedrock/use-case-examples/text-2-sql-agent-cdk-enhanced/Prep_Data.py
+++ b/agents-for-bedrock/use-case-examples/text-2-sql-agent-cdk-enhanced/Prep_Data.py
@@ -1,0 +1,52 @@
+import os
+import shutil
+import zipfile
+
+
+def prep_data(main_folder):
+    
+    # Directory containing the zip file
+    source_dir = './Data'
+    # Main folder to be created
+
+    # Path to the main folder
+    main_folder_path = os.path.join(source_dir, main_folder)
+
+    # Path to the zip file
+    zip_file_path = os.path.join(source_dir, f'{main_folder}.zip')
+
+    # Check if the main folder exists, and if so, delete it
+    if os.path.exists(main_folder_path):
+        shutil.rmtree(main_folder_path)
+
+    # Unzip the file directly to the source_dir to prevent nested folders with the same name
+    with zipfile.ZipFile(zip_file_path, 'r') as zip_ref:
+        zip_ref.extractall(source_dir)
+
+    # Rename the unzipped main folder if it creates an extra unwanted level
+    extracted_main_folder_path = os.path.join(source_dir, main_folder)
+    if os.path.exists(extracted_main_folder_path) and os.path.isdir(extracted_main_folder_path):
+        # List contents to see if there is an unwanted nested structure
+        contents = os.listdir(extracted_main_folder_path)
+        if len(contents) == 1 and os.path.isdir(os.path.join(extracted_main_folder_path, contents[0])):
+            nested_folder_path = os.path.join(extracted_main_folder_path, contents[0])
+            # Move contents from nested folder to correct location
+            for item in os.listdir(nested_folder_path):
+                shutil.move(os.path.join(nested_folder_path, item), extracted_main_folder_path)
+            # Remove the now empty nested directory
+            os.rmdir(nested_folder_path)
+
+    # Optionally, now move and organize files into their respective folders as needed
+    for root, dirs, files in os.walk(extracted_main_folder_path, topdown=False):
+        for name in files:
+            if name.endswith('.csv'):
+                file_path = os.path.join(root, name)
+                folder_name = name[:-4]
+                new_folder_path = os.path.join(root, folder_name)
+                if not os.path.exists(new_folder_path):
+                    os.makedirs(new_folder_path)
+                shutil.move(file_path, os.path.join(new_folder_path, name))
+
+    print("Files have been organized in nested folders correctly.")
+
+

--- a/agents-for-bedrock/use-case-examples/text-2-sql-agent-cdk-enhanced/Readme.md
+++ b/agents-for-bedrock/use-case-examples/text-2-sql-agent-cdk-enhanced/Readme.md
@@ -22,7 +22,7 @@ The Agent is designed to:
 This repository enhances the original Text to SQL Bedrock Agent with the following improvements:
 
 - Uses AWS CDK to build the necessary infrastructure.
-- Works with any dataset: simply create a folder with all your data in CSV files, create a zip file of this folder, place it in the "Data" directory, and the code will automatically extract and upload the files, generating the necessary instructions. Provide the zip file name at the time of deployment (cdk deploy --profile XXX --context zip_file_name=EV_WA.zip).
+- Works with any dataset: simply create a folder with all your data in CSV files, create a zip file of this folder, place it in the "Data" directory, and the code will automatically extract and upload the files, generating the necessary instructions. Provide the zip file name at the time of deployment (cdk deploy --profile XXX --context zip_file_name=EV_WA.zip --context region=us-east-1).
 - If the answer is large, it creates a file in S3 and points the user to the S3 location.
 
 
@@ -65,7 +65,7 @@ If you want to run this with sample data, use the data provided as an example, w
 
 ```bash
 cdk bootstrap --profile XXX --context zip_file_name=EV_WA.zip
-cdk deploy --profile XXX --context zip_file_name=EV_WA.zip
+cdk deploy --profile XXX --context zip_file_name=EV_WA.zip --context region=us-east-1
 ```
 
 Feel free to use this for your own data. If you want to deploy with your own data on your existing infrastructure, you can do that. Just make sure to stop your crawler schedule, then deploy with the new data, and then resume the schedule. However, if it is a fresh deployment with your data, you don't need to do anything extra.

--- a/agents-for-bedrock/use-case-examples/text-2-sql-agent-cdk-enhanced/Readme.md
+++ b/agents-for-bedrock/use-case-examples/text-2-sql-agent-cdk-enhanced/Readme.md
@@ -64,6 +64,7 @@ Deploy the stack using the AWS CDK.
 If you want to run this with sample data, use the data provided as an example, which is "EV_WA.zip" in the "Data" directory. This is public data from [Electric Vehicle Population Data](https://catalog.data.gov/dataset/electric-vehicle-population-data). This dataset shows the Battery Electric Vehicles (BEVs) and Plug-in Hybrid Electric Vehicles (PHEVs) that are currently registered through the Washington State Department of Licensing (DOL). For the purpose of this repository, the data was split into 4 CSV files by the author. 
 
 ```bash
+cdk bootstrap --profile XXX
 cdk deploy --profile XXX --context zip_file_name=EV_WA.zip
 ```
 

--- a/agents-for-bedrock/use-case-examples/text-2-sql-agent-cdk-enhanced/Readme.md
+++ b/agents-for-bedrock/use-case-examples/text-2-sql-agent-cdk-enhanced/Readme.md
@@ -71,7 +71,7 @@ cdk deploy --profile XXX --context zip_file_name=EV_WA.zip
 Feel free to use this for your own data. If you want to deploy with your own data on your existing infrastructure, you can do that. Just make sure to stop your crawler schedule, then deploy with the new data, and then resume the schedule. However, if it is a fresh deployment with your data, you don't need to do anything extra.
 
 ## Usage
-After deployment is finished, wait for 1 minute for the crawling to complete. Then go to the AWS Bedrock console, navigate to the agent section, find your agent, and test your agent with a question, for example:
+After deployment is finished, wait for 2 minute for the first crawling of database to complete. Then go to the AWS Bedrock console, navigate to the agent section, find your agent, and test your agent with a question, for example:
 
 "What are the 5 model years and types of electric vehicles available in Thurston County?"
 

--- a/agents-for-bedrock/use-case-examples/text-2-sql-agent-cdk-enhanced/Readme.md
+++ b/agents-for-bedrock/use-case-examples/text-2-sql-agent-cdk-enhanced/Readme.md
@@ -12,8 +12,11 @@ Harnessing the power of natural language processing, the "Text to SQL Bedrock Ag
 ## Use Case
 The code here sets up an agent capable of crafting SQL queries from natural language questions. It then retrieves responses from the database, providing accurate answers to user inquiries. The diagram below outlines the high-level architecture of this solution.
 
+The Agent is designed to:
+- Retrieve database schemas
+- Execute SQL queries
 
-##  ##  Differences from [text-2-sql-agent](https://github.com/aws-samples/amazon-bedrock-samples/tree/main/agents-for-bedrock/use-case-examples/text-2-sql-agent)
+## Differences from [text-2-sql-agent](https://github.com/aws-samples/amazon-bedrock-samples/tree/main/agents-for-bedrock/use-case-examples/text-2-sql-agent)
 
 
 This repository enhances the original Text to SQL Bedrock Agent with the following improvements:
@@ -23,9 +26,7 @@ This repository enhances the original Text to SQL Bedrock Agent with the followi
 - If the answer is large, it creates a file in S3 and points the user to the S3 location.
 
 
-The Agent is designed to:
-- Retrieve database schemas
-- Execute SQL queries
+
 
 ## Prerequisites
 Before you begin, ensure you have the following:

--- a/agents-for-bedrock/use-case-examples/text-2-sql-agent-cdk-enhanced/Readme.md
+++ b/agents-for-bedrock/use-case-examples/text-2-sql-agent-cdk-enhanced/Readme.md
@@ -64,7 +64,7 @@ Deploy the stack using the AWS CDK.
 If you want to run this with sample data, use the data provided as an example, which is "EV_WA.zip" in the "Data" directory. This is public data from [Electric Vehicle Population Data](https://catalog.data.gov/dataset/electric-vehicle-population-data). This dataset shows the Battery Electric Vehicles (BEVs) and Plug-in Hybrid Electric Vehicles (PHEVs) that are currently registered through the Washington State Department of Licensing (DOL). For the purpose of this repository, the data was split into 4 CSV files by the author. 
 
 ```bash
-cdk bootstrap --profile XXX
+cdk bootstrap --profile XXX --context zip_file_name=EV_WA.zip
 cdk deploy --profile XXX --context zip_file_name=EV_WA.zip
 ```
 

--- a/agents-for-bedrock/use-case-examples/text-2-sql-agent-cdk-enhanced/Readme.md
+++ b/agents-for-bedrock/use-case-examples/text-2-sql-agent-cdk-enhanced/Readme.md
@@ -94,5 +94,5 @@ This dataset shows the Battery Electric Vehicles (BEVs) and Plug-in Hybrid Elect
 To delete all resources created and avoid ongoing charges, run .
 
 ```bash
-cdk destroy --profile XXX
+cdk destroy --profile XXX --context zip_file_name=EV_WA.zip --context region=us-east-1
 ```

--- a/agents-for-bedrock/use-case-examples/text-2-sql-agent-cdk-enhanced/Readme.md
+++ b/agents-for-bedrock/use-case-examples/text-2-sql-agent-cdk-enhanced/Readme.md
@@ -50,7 +50,7 @@ Clone the repository to your local machine or AWS environment, set up a virtual 
 
 ```bash
 git clone https://github.com/aws-samples/amazon-bedrock-samples.git
-cd ./agents-for-bedrock/use-case-examples/text-2-sql-agent-cdk-enhanced
+cd ./amazon-bedrock-samples/agents-for-bedrock/use-case-examples/text-2-sql-agent-cdk-enhanced
 export AWS_PROFILE=XXX
 python3.9 -m venv .venv
 source .venv/bin/activate

--- a/agents-for-bedrock/use-case-examples/text-2-sql-agent-cdk-enhanced/Readme.md
+++ b/agents-for-bedrock/use-case-examples/text-2-sql-agent-cdk-enhanced/Readme.md
@@ -75,6 +75,18 @@ After deployment is finished, wait for 2 minute for the first crawling of databa
 
 "What are the 5 model years and types of electric vehicles available in Thurston County?"
 
+## Data
+This project uses the Electric Vehicle Population Data, which is under the Open Data Commons Open Database License (ODbL) v1.0. You can find the dataset [here](https://catalog.data.gov/dataset/electric-vehicle-population-data) and the license details [here](https://opendatacommons.org/licenses/odbl/1-0/).
+
+### Conditions for Use:
+- You will cite the dataset in your documentation/scientific publication as appropriate.
+- You will include a link to the source of the original dataset with the dataset.
+- You will abide by the terms of the ODbL license for attribution and attachment of the license to data.
+- You will prominently identify the data as being under the ODbL license. Our customers need to be made aware of the usage in a way that allows them to make reasoned decisions.
+
+
+### Citation:
+This dataset shows the Battery Electric Vehicles (BEVs) and Plug-in Hybrid Electric Vehicles (PHEVs) that are currently registered through the Washington State Department of Licensing (DOL). For the purpose of this repository, the data was split into 4 CSV files by the author. 
 
 
 ## Cleaning Up

--- a/agents-for-bedrock/use-case-examples/text-2-sql-agent-cdk-enhanced/Readme.md
+++ b/agents-for-bedrock/use-case-examples/text-2-sql-agent-cdk-enhanced/Readme.md
@@ -13,7 +13,9 @@ Harnessing the power of natural language processing, the "Text to SQL Bedrock Ag
 The code here sets up an agent capable of crafting SQL queries from natural language questions. It then retrieves responses from the database, providing accurate answers to user inquiries. The diagram below outlines the high-level architecture of this solution.
 
 
-##  Differences from Original Repo (https://github.com/aws-samples/amazon-bedrock-samples/tree/main/agents-for-bedrock/use-case-examples/text-2-sql-agent)
+##  ##  Differences from [text-2-sql-agent](https://github.com/aws-samples/amazon-bedrock-samples/tree/main/agents-for-bedrock/use-case-examples/text-2-sql-agent)
+
+
 This repository enhances the original Text to SQL Bedrock Agent with the following improvements:
 
 - Uses AWS CDK to build the necessary infrastructure.
@@ -27,7 +29,7 @@ The Agent is designed to:
 
 ## Prerequisites
 Before you begin, ensure you have the following:
-- An AWS account with the following permissions:
+- An AWS account (AWS_PROFILE) with the following permissions:
   - Create and manage IAM roles and policies.
   - Create and invoke AWS Lambda functions.
   - Create, read from, and write to Amazon S3 buckets.
@@ -48,7 +50,7 @@ Clone the repository to your local machine or AWS environment:
 
 ```bash
 git clone https://github.com/aws-samples/amazon-bedrock-samples.git
-cd agents-for-bedrock/use-case-examples/text-2-sql-agent-cdk-enhanced
+cd ./agents-for-bedrock/use-case-examples/text-2-sql-agent-cdk-enhanced
 export AWS_PROFILE=XXX
 python3.9 -m venv .venv
 source .venv/bin/activate
@@ -59,7 +61,7 @@ chmod +x setup.sh
 
 ## Deployment 
 Deploy the stack using the AWS CDK. 
-If you want to run this with sample data, use the data provided as an example, which is "EV_WA.zip" in the "Data" directory. This is public data from Electric Vehicle Population Data (https://catalog.data.gov/dataset/electric-vehicle-population-data). This dataset shows the Battery Electric Vehicles (BEVs) and Plug-in Hybrid Electric Vehicles (PHEVs) that are currently registered through the Washington State Department of Licensing (DOL). For the purpose of this repository, the data was split into 4 CSV files by the author. 
+If you want to run this with sample data, use the data provided as an example, which is "EV_WA.zip" in the "Data" directory. This is public data from [Electric Vehicle Population Data](https://catalog.data.gov/dataset/electric-vehicle-population-data). This dataset shows the Battery Electric Vehicles (BEVs) and Plug-in Hybrid Electric Vehicles (PHEVs) that are currently registered through the Washington State Department of Licensing (DOL). For the purpose of this repository, the data was split into 4 CSV files by the author. 
 
 ```bash
 cdk deploy --profile XXX --context zip_file_name=EV_WA.zip

--- a/agents-for-bedrock/use-case-examples/text-2-sql-agent-cdk-enhanced/Readme.md
+++ b/agents-for-bedrock/use-case-examples/text-2-sql-agent-cdk-enhanced/Readme.md
@@ -30,6 +30,10 @@ This repository enhances the original Text to SQL Bedrock Agent with the followi
 
 ## Prerequisites
 Before you begin, ensure you have the following:
+- AWS CLI installed and configured with the necessary permissions
+- Node.js and npm
+- Python 3.9 or higher and pip
+- Access to Amazon Bedrock foundation models (Before you can use a foundation model in Amazon Bedrock, you must request access to it. Use this Link for detail https://docs.aws.amazon.com/bedrock/latest/userguide/model-access.html)
 - An AWS account (AWS_PROFILE) with the following permissions:
   - Create and manage IAM roles and policies.
   - Create and invoke AWS Lambda functions.
@@ -47,7 +51,7 @@ Before you begin, ensure you have the following:
   - Use the Data Science 3.0 kernel in SageMaker Studio
 
 ## Installation
-Clone the repository to your local machine or AWS environment:
+Clone the repository to your local machine or AWS environment, set up a virtual environment and activate it and install the AWS CDK and required Python packages using below code:
 
 ```bash
 git clone https://github.com/aws-samples/amazon-bedrock-samples.git

--- a/agents-for-bedrock/use-case-examples/text-2-sql-agent-cdk-enhanced/Readme.md
+++ b/agents-for-bedrock/use-case-examples/text-2-sql-agent-cdk-enhanced/Readme.md
@@ -1,0 +1,83 @@
+# Text to SQL Bedrock Agent CDK Enhanced
+
+## Authors:
+- **Pedram Jahangiri** [@iut62elec](https://github.com/iut62elec)
+
+## Reviewer:
+- **Maira Ladeira Tanke** [@mttanke](https://github.com/mttanke)
+
+## Introduction
+Harnessing the power of natural language processing, the "Text to SQL Bedrock Agent" facilitates the automatic transformation of natural language questions into executable SQL queries. This tool bridges the gap between complex database structures and intuitive human inquiries, enabling users to effortlessly extract insights from data using simple English prompts. It leverages AWS Bedrock's cutting-edge agent technology and exemplifies the synergy between AWS's robust infrastructure and advanced large language models offered in AWS Bedrock, making sophisticated data analysis accessible to a wider audience. This repository contains the necessary files to set up and test a Text to SQL conversion using the Bedrock Agent with AWS services.
+
+## Use Case
+The code here sets up an agent capable of crafting SQL queries from natural language questions. It then retrieves responses from the database, providing accurate answers to user inquiries. The diagram below outlines the high-level architecture of this solution.
+
+
+##  Differences from Original Repo (https://github.com/aws-samples/amazon-bedrock-samples/tree/main/agents-for-bedrock/use-case-examples/text-2-sql-agent)
+This repository enhances the original Text to SQL Bedrock Agent with the following improvements:
+
+- Uses AWS CDK to build the necessary infrastructure.
+- Works with any dataset: simply create a folder with all your data in CSV files, create a zip file of this folder, place it in the "Data" directory, and the code will automatically extract and upload the files, generating the necessary instructions. Provide the zip file name at the time of deployment (cdk deploy --profile XXX --context zip_file_name=EV_WA.zip).
+- If the answer is large, it creates a file in S3 and points the user to the S3 location.
+
+
+The Agent is designed to:
+- Retrieve database schemas
+- Execute SQL queries
+
+## Prerequisites
+Before you begin, ensure you have the following:
+- An AWS account with the following permissions:
+  - Create and manage IAM roles and policies.
+  - Create and invoke AWS Lambda functions.
+  - Create, read from, and write to Amazon S3 buckets.
+  - Access and manage Amazon Bedrock agents and models.
+  - Create and manage Amazon Glue databases and crawlers.
+  - Execute queries and manage workspaces in Amazon Athena.
+  - Access to Amazon Bedrock foundation models (Anthropic’s Claude 3 Sonnet model for this solution)
+
+- For local setup:
+  - Python and Jupyter Notebooks installed
+  - AWS CLI installed and configured
+- For AWS SageMaker:
+  - Ensure your domain has the above permissions
+  - Use the Data Science 3.0 kernel in SageMaker Studio
+
+## Installation
+Clone the repository to your local machine or AWS environment:
+
+```bash
+git clone https://github.com/aws-samples/amazon-bedrock-samples.git
+cd agents-for-bedrock/use-case-examples/text-2-sql-agent-cdk-enhanced
+export AWS_PROFILE=XXX
+python3.9 -m venv .venv
+source .venv/bin/activate
+aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws
+chmod +x setup.sh
+./setup.sh
+```
+
+## Deployment 
+Deploy the stack using the AWS CDK. 
+If you want to run this with sample data, use the data provided as an example, which is "EV_WA.zip" in the "Data" directory. This is public data from Electric Vehicle Population Data (https://catalog.data.gov/dataset/electric-vehicle-population-data). This dataset shows the Battery Electric Vehicles (BEVs) and Plug-in Hybrid Electric Vehicles (PHEVs) that are currently registered through the Washington State Department of Licensing (DOL). For the purpose of this repository, the data was split into 4 CSV files by the author. 
+
+```bash
+cdk deploy --profile XXX --context zip_file_name=EV_WA.zip
+```
+
+Feel free to use this for your own data. If you want to deploy with your own data on your existing infrastructure, you can do that. Just make sure to stop your crawler schedule, then deploy with the new data, and then resume the schedule. However, if it is a fresh deployment with your data, you don't need to do anything extra.
+
+## Usage
+After deployment is finished, wait for 1 minute for the crawling to complete. Then go to the AWS Bedrock console, navigate to the agent section, find your agent, and test your agent with a question, for example:
+
+"What are the 5 model years and types of electric vehicles available in Thurston County?"
+
+
+
+## Cleaning Up
+
+To delete all resources created and avoid ongoing charges, run .
+
+```bash
+cdk destroy --profile XXX
+```

--- a/agents-for-bedrock/use-case-examples/text-2-sql-agent-cdk-enhanced/Readme.md
+++ b/agents-for-bedrock/use-case-examples/text-2-sql-agent-cdk-enhanced/Readme.md
@@ -43,12 +43,7 @@ Before you begin, ensure you have the following:
   - Execute queries and manage workspaces in Amazon Athena.
   - Access to Amazon Bedrock foundation models (Anthropic’s Claude 3 Sonnet model for this solution)
 
-- For local setup:
-  - Python and Jupyter Notebooks installed
-  - AWS CLI installed and configured
-- For AWS SageMaker:
-  - Ensure your domain has the above permissions
-  - Use the Data Science 3.0 kernel in SageMaker Studio
+
 
 ## Installation
 Clone the repository to your local machine or AWS environment, set up a virtual environment and activate it and install the AWS CDK and required Python packages using below code:

--- a/agents-for-bedrock/use-case-examples/text-2-sql-agent-cdk-enhanced/agent_instruction_generator.py
+++ b/agents-for-bedrock/use-case-examples/text-2-sql-agent-cdk-enhanced/agent_instruction_generator.py
@@ -1,0 +1,96 @@
+import os
+import pandas as pd
+import boto3
+import json
+from botocore.config import Config
+from claude_3 import Claude3Wrapper, invoke_claude_3_with_text
+def analyze_csv_files(root_folder):
+    data_context = {}
+
+    # Walk through all directories and files in the root folder
+    for dirpath, dirnames, filenames in os.walk(root_folder):
+        for file in filenames:
+            if file.endswith('.csv'):
+                # Construct the full file path
+                file_path = os.path.join(dirpath, file)
+                
+                # Read the CSV file
+                df = pd.read_csv(file_path)
+                
+                # Get column names and sample data
+                columns = df.columns.tolist()
+                sample_data = df.head(1).to_dict(orient='records')[0]
+                
+                # Use relative path from root_folder as key to handle different files with the same name in different folders
+                relative_path = os.path.relpath(file_path, start=root_folder)
+                
+                # Store this info
+                #relative_path
+                data_context[relative_path.replace('.csv', '').split('/')[0].replace(' ','_')] = {
+                    'columns': columns,
+                    'sample_data': sample_data
+                }
+
+    return data_context
+
+data_folder_name = "xxx"
+data_folder = f'./Data/{data_folder_name}'
+glue_database_name = f"{data_folder_name.lower()}"
+
+data_context = analyze_csv_files(data_folder)
+#print(data_context)
+
+if 1==1:
+    def generate_instruction(data_context, glue_database_name):
+     
+        instruction_parts = [
+            f"You are an advanced database querying agent crafted specifically for generating precise SQL queries concerning the {glue_database_name} database. Your tasks involve creating syntactically correct AWS Athena queries tailored to specific questions. Always ensure that:",
+            "1. Queries are efficient, targeting only a few relevant columns rather than extracting all data from any table.",
+            "2. You utilize only those column names that are visible in the schema description to avoid referencing non-existent columns.",
+            "3. You accurately identify the table each column belongs to, and",
+            "4. Appropriately qualify column names with their respective table names as necessary.",
+            "5. Always enclose table names and column names in DOUBLE quotes. This is super important as it is the required format for AWS Athena and helps prevent potential errors due to case sensitivity or special characters.",
+            "6. For queries with filters based on categorical data first generate a sample a SQL query (using distinct) against relevant tables to familiarize yourself with the content of a particular column"
+            f"7. After reviewing the schema of the entire {glue_database_name} and the columns of the tables, decide on your final SQL query to answer the question. Remember, to answer a question thoroughly (or provide AWS S3 link of response), you might need to perform joins between tables. Your final SQL query requires a deep understanding of the relationships within the database to construct effective and accurate queries.",
+            "The following examples illustrate the kind of queries you should be able to construct based on the available data:"
+        ]
+
+        
+        for file, context in data_context.items():
+            #table_name = file.replace('.csv', '').split('/')[0]
+            table_name = file
+            columns = ', '.join([f'"{col}"' for col in context['columns'] if ' ' in col or not col.isidentifier()])
+            sample_query = f"SELECT \"{columns}\" FROM \"{table_name}\" LIMIT 5;"
+            instruction_parts.append(f"- Table `{table_name}` example query: {sample_query}")
+        
+        return ' '.join(instruction_parts)
+
+    instruction_text = generate_instruction(data_context, glue_database_name)
+    #print(instruction_text)
+
+
+    # question = f"""
+    # Please craft a comprehensive instruction UP TO 1200 WORDS (this is a hard constraint max Length should be lower than 1200 words) for the Bedrock agent (Instructions that tell the agent what it should do and how it should interact with users). Your instruction must be based on ALL 7 CONTEXTUAL DETAILS provided to develop this instruction text. The final submission should consist solely of your detailed instruction without saying for example "here is your...\n
+    
+    # {instruction_text}.
+    
+    # """
+    question = f"""
+    Craft a comprehensive and cohesive instruction in one full paragraph for the Bedrock agent, with a Maximum length of 1200 characters (1200 characters is hard limit so adhere to this limit on generating text). These instructions should clearly outline the agent's tasks and how it should interact with users. Ensure that your instruction is based on all seven contextual details provided. The final answer should be concise, detailed and precise, without any introductory phrases such as "Here is your...".
+
+    Contextual details:
+    {instruction_text}
+    """
+
+
+
+    # Invoke Claude 3 with a text prompt
+    text_prompt = question
+   
+
+    instruction=invoke_claude_3_with_text(question)
+
+
+    #print(text_prompt)
+    #print("\n \n here is instruction \n \n")
+    #print(instruction)

--- a/agents-for-bedrock/use-case-examples/text-2-sql-agent-cdk-enhanced/app.py
+++ b/agents-for-bedrock/use-case-examples/text-2-sql-agent-cdk-enhanced/app.py
@@ -1,0 +1,221 @@
+from aws_cdk import App, Stack, RemovalPolicy
+from aws_cdk import aws_s3 as s3
+from aws_cdk import aws_lambda as lambda_
+from aws_cdk import aws_glue as glue
+from aws_cdk import aws_iam as iam
+from aws_cdk.aws_s3_deployment import BucketDeployment, Source
+import aws_cdk as cdk
+from aws_cdk.aws_lambda import Runtime
+from aws_cdk.aws_lambda_python_alpha import PythonFunction
+from cdklabs.generative_ai_cdk_constructs import (
+    bedrock)
+
+from cdklabs.generative_ai_cdk_constructs.bedrock import (
+    Agent, ApiSchema, BedrockFoundationModel,AgentActionGroup
+)
+from aws_cdk import aws_events as events
+from aws_cdk import aws_cloudformation as cfn
+
+from aws_cdk import aws_events_targets as events_targets
+# from aws_cdk import custom_resources
+#from aws_cdk import core as cdk
+from aws_cdk import Duration  # Import Duration directly
+
+
+from constructs import Construct
+from agent_instruction_generator import analyze_csv_files,generate_instruction,invoke_claude_3_with_text
+
+from Prep_Data import prep_data
+
+class MyStack(Stack):
+    def __init__(self, scope: App, id: str,zip_file_name: str, **kwargs):
+        super().__init__(scope, id, **kwargs)
+
+        # General setup
+        region = cdk.Stack.of(self).region
+        account_id = cdk.Stack.of(self).account
+       
+        #zip_file_name='EV_WA.zip'
+        
+        
+        data_folder_name=zip_file_name.replace('.zip','')
+        agent_name = f"agent_{data_folder_name.lower()}"
+        suffix = f"{region}-{account_id}-{agent_name.lower()}"
+
+        lambda_role_name = f'{agent_name}-lambda-role-{suffix}'
+        agent_role_name = f'AmazonBedrockExecutionRoleForAgents_{suffix}'
+        lambda_name = f'{agent_name}-{suffix}'
+    
+        foundation_model = BedrockFoundationModel('anthropic.claude-3-sonnet-20240229-v1:0', supports_agents=True)
+        
+        
+        prep_data(data_folder_name)
+        
+        glue_database_name = f"{data_folder_name.lower()}"
+        # Create an S3 bucket
+        schema_bucket = s3.Bucket(self, "SchemaBucket",removal_policy=RemovalPolicy.DESTROY, auto_delete_objects=True)
+
+        # Upload files to S3
+        # Upload the unzipped data to S3
+        deployment = BucketDeployment(self, "DeployFiles",
+                                      sources=[Source.asset(f"./data/{data_folder_name}")], 
+                                      destination_bucket=schema_bucket,
+                                      destination_key_prefix=f"data/{data_folder_name}/")
+
+        # Define the IAM role for Glue
+        glue_role = iam.Role(self, "GlueRole",
+                             assumed_by=iam.ServicePrincipal("glue.amazonaws.com"),
+                             managed_policies=[
+                                 iam.ManagedPolicy.from_aws_managed_policy_name("service-role/AWSGlueServiceRole"),
+                                 iam.ManagedPolicy.from_aws_managed_policy_name("AmazonS3FullAccess")
+                             ])
+        glue_database = glue.CfnDatabase(self, "GlueDatabase",
+            catalog_id=account_id,
+            database_input=glue.CfnDatabase.DatabaseInputProperty(
+                name=glue_database_name
+            )
+        )
+        # Create a Glue Crawler
+        crawler_name = "MyCrawler"  # Define the crawler name as a variable
+        crawler = glue.CfnCrawler(self, crawler_name,
+                                role=glue_role.role_arn,
+                                database_name=glue_database_name,
+                                schedule=glue.CfnCrawler.ScheduleProperty(
+                                                schedule_expression="cron(0/1 * * * ? *)"
+                                            ),
+                                targets={"s3Targets": [{
+                                    "path": f"s3://{schema_bucket.bucket_name}/data/{data_folder_name}/"
+                                }]})
+
+        
+      
+       
+        
+        
+        athena_result_loc = f"s3://{schema_bucket.bucket_name}/athena_result/"
+
+        
+
+        # Create a Lambda function for action group
+        action_group_function = lambda_.Function(
+            self,
+            "ActionGroupFunction",
+            runtime=lambda_.Runtime.PYTHON_3_9,
+            handler="index.lambda_handler",
+            code=lambda_.Code.from_asset("./lambda/agent/"),
+            environment={
+              'outputLocation': athena_result_loc,
+              'glue_database_name': glue_database_name,
+              'region':region,
+              'bucket_name':schema_bucket.bucket_name
+            },
+            
+            timeout= Duration.minutes(5),
+            memory_size=512,
+        )
+        
+        # Fine-tuning IAM policies
+        action_group_function.role.add_to_policy(iam.PolicyStatement(
+            actions=["glue:StartJobRun"],
+            resources=[f"arn:aws:glue:{region}:{account_id}:job/*"]
+        ))
+        action_group_function.role.add_to_policy(iam.PolicyStatement(
+            actions=[
+                "glue:GetDatabase", "glue:GetDatabases", "glue:GetTable", "glue:GetTables",
+                "glue:BatchGetPartition", "glue:GetPartition", "glue:GetPartitions",
+                "glue:BatchCreatePartition", "glue:CreatePartition", "glue:DeletePartition",
+                "glue:UpdatePartition", "glue:BatchDeletePartition"
+            ],
+            resources=[f"arn:aws:glue:{region}:{account_id}:catalog",
+                       f"arn:aws:glue:{region}:{account_id}:database/{glue_database_name}",
+                       f"arn:aws:glue:{region}:{account_id}:table/{glue_database_name}/*"]
+        ))
+        action_group_function.role.add_to_policy(iam.PolicyStatement(
+            actions=["s3:PutObject", "s3:GetObject", "s3:ListBucket","s3:CreateBucket", "s3:GetBucketLocation"],
+            resources=[f"{schema_bucket.bucket_arn}", f"{schema_bucket.bucket_arn}/*"]
+        ))
+        action_group_function.role.add_to_policy(iam.PolicyStatement(
+            actions=[
+                "athena:StartQueryExecution", "athena:GetQueryExecution",
+                "athena:GetQueryResults", "athena:StopQueryExecution",
+                "athena:GetWorkGroup"
+            ],
+            resources=[f"arn:aws:athena:{region}:{account_id}:workgroup/primary"]
+        ))
+
+        
+        
+        data_folder = f'./Data/{data_folder_name}'
+
+        data_context = analyze_csv_files(data_folder)
+        
+        instruction_text = generate_instruction(data_context, glue_database_name)
+        # question = f"""
+        #     Please craft a comprehensive, single-paragraph instruction (up to 1200 words) for the Bedrock agent. Incorporate all the contextual details provided below to develop this instruction text. The final submission should consist solely of this detailed instruction.\n
+        #     {instruction_text}.
+        #     """ 
+            
+        question = f"""
+            Craft a comprehensive and cohesive instruction in one full paragraph for the Bedrock agent, with a Maximum length of 1200 characters (1200 characters is hard limit so adhere to this limit on generating text). These instructions should clearly outline the agent's tasks and how it should interact with users. Ensure that your instruction is based on all seven contextual details provided. The final answer should be detailed and precise, without any introductory phrases such as "Here is your...".
+
+            Contextual details:
+            {instruction_text}
+            """       
+        agent_instruction=invoke_claude_3_with_text(question)    
+        print(agent_instruction)
+        
+        api_schema = ApiSchema.from_asset("./text_to_sql_openapi_schema.json")
+        agent = Agent(
+            self,
+            "MyAgent",
+            foundation_model=foundation_model,
+            instruction=agent_instruction,
+            description="Agent for performing sql queries.",
+            should_prepare_agent=True
+          
+        )
+        # agent.add_alias(self, 'ProdAlias', 
+        #     alias_name='prod',
+        #     agent_version='1'
+        #     )   
+        action_group = AgentActionGroup(self,
+            "MyActionGroup",
+            action_group_name="QueryAthenaActionGroup",
+            description="Actions for getting the database schema and querying the Athena database for sample data or final query.",
+            action_group_executor=action_group_function,
+            action_group_state="ENABLED",
+            api_schema=api_schema)
+        
+        agent.add_action_group(action_group)
+        
+        # agent.add_action_group(
+        #     description="Actions for getting the database schema and querying the Athena database for sample data or final query",
+        #     action_group_executor=action_group_function,
+        #     action_group_state="ENABLED",
+        #     api_schema=api_schema
+        # )
+        
+         # IAM Role for Agent
+        agent_role = iam.Role(self, "AgentRole",
+                              assumed_by=iam.ServicePrincipal("bedrock.amazonaws.com"),
+                            )
+
+        # Attach IAM policies for agent to interact with AWS services
+        agent_role.add_to_policy(iam.PolicyStatement(
+            actions=["s3:GetObject", "s3:ListBucket"],
+            resources=[schema_bucket.bucket_arn, f"{schema_bucket.bucket_arn}/*"]
+        ))
+        
+        action_group_function.add_permission(
+            "AllowBedrockInvoke",
+            principal=iam.ServicePrincipal("bedrock.amazonaws.com"),
+            action="lambda:InvokeFunction",
+            source_arn=f"arn:aws:bedrock:{region}:{account_id}:agent/*"
+        )
+        print("agent id:",agent.agent_id,agent.agent_arn)
+
+
+app = App()
+zip_file_name = app.node.try_get_context("zip_file_name")
+MyStack(app, "text-2-sql2", zip_file_name=zip_file_name)
+app.synth()

--- a/agents-for-bedrock/use-case-examples/text-2-sql-agent-cdk-enhanced/app.py
+++ b/agents-for-bedrock/use-case-examples/text-2-sql-agent-cdk-enhanced/app.py
@@ -20,6 +20,7 @@ from aws_cdk import aws_events_targets as events_targets
 # from aws_cdk import custom_resources
 #from aws_cdk import core as cdk
 from aws_cdk import Duration  # Import Duration directly
+from cdklabs.generative_ai_cdk_constructs.bedrock import ActionGroupExecutor
 
 
 from constructs import Construct
@@ -58,7 +59,7 @@ class MyStack(Stack):
         # Upload files to S3
         # Upload the unzipped data to S3
         deployment = BucketDeployment(self, "DeployFiles",
-                                      sources=[Source.asset(f"./data/{data_folder_name}")], 
+                                      sources=[Source.asset(f"./Data/{data_folder_name}")], 
                                       destination_bucket=schema_bucket,
                                       destination_key_prefix=f"data/{data_folder_name}/")
 
@@ -113,6 +114,16 @@ class MyStack(Stack):
             timeout= Duration.minutes(5),
             memory_size=512,
         )
+        
+        
+        # action_group_function = PythonFunction(
+        #     self,
+        #     "ActionGroupFunction",
+        #     runtime=Runtime.PYTHON_3_9,
+        #     entry="./lambda",  
+        #     index="app.py",
+        #     handler="lambda_handler",
+        # )
         
         # Fine-tuning IAM policies
         action_group_function.role.add_to_policy(iam.PolicyStatement(
@@ -181,13 +192,20 @@ class MyStack(Stack):
         #     alias_name='prod',
         #     agent_version='1'
         #     )   
-        action_group = AgentActionGroup(self,
+        
+      
+
+        action_group = AgentActionGroup(
+            self,
             "MyActionGroup",
             action_group_name="QueryAthenaActionGroup",
             description="Actions for getting the database schema and querying the Athena database for sample data or final query.",
-            action_group_executor=action_group_function,
+            action_group_executor=ActionGroupExecutor(lambda_=action_group_function),  
             action_group_state="ENABLED",
-            api_schema=api_schema)
+            api_schema=api_schema
+        )
+        
+       
         
         agent.add_action_group(action_group)
        

--- a/agents-for-bedrock/use-case-examples/text-2-sql-agent-cdk-enhanced/app.py
+++ b/agents-for-bedrock/use-case-examples/text-2-sql-agent-cdk-enhanced/app.py
@@ -28,11 +28,11 @@ from agent_instruction_generator import analyze_csv_files,generate_instruction,i
 from Prep_Data import prep_data
 
 class MyStack(Stack):
-    def __init__(self, scope: App, id: str,zip_file_name: str, **kwargs):
+    def __init__(self, scope: App, id: str,zip_file_name: str, region: str, **kwargs):
         super().__init__(scope, id, **kwargs)
 
         # General setup
-        region = cdk.Stack.of(self).region
+        #region = cdk.Stack.of(self).region
         account_id = cdk.Stack.of(self).account
        
         #zip_file_name='EV_WA.zip'
@@ -155,12 +155,15 @@ class MyStack(Stack):
         #     {instruction_text}.
         #     """ 
             
+        
         question = f"""
-            Craft a comprehensive and cohesive instruction in one full paragraph for the Bedrock agent, with a Maximum length of 1200 characters (1200 characters is hard limit so adhere to this limit on generating text). These instructions should clearly outline the agent's tasks and how it should interact with users. Ensure that your instruction is based on all seven contextual details provided. The final answer should be detailed and precise, without any introductory phrases such as "Here is your...".
+            Craft a comprehensive and cohesive paragraph instruction for the Bedrock agent, ensuring the instruction text includes all 7 contextual details and examples provided. The instruction should be detailed, precise with a maximum length of 4000 characters. Clearly outline the agent's tasks and how it should interact with users, incorporating the provided contextual details and examples with minimal changes. Avoid any introductory phrases such as "Here is your...".
 
-            Contextual details:
+            <Contextual details and examples>
             {instruction_text}
-            """       
+            """
+   
+                 
         agent_instruction=invoke_claude_3_with_text(question)    
         print(agent_instruction)
         
@@ -217,5 +220,6 @@ class MyStack(Stack):
 
 app = App()
 zip_file_name = app.node.try_get_context("zip_file_name")
-MyStack(app, "text-2-sql2", zip_file_name=zip_file_name)
+region = app.node.try_get_context("region")
+MyStack(app, "text-2-sql2", zip_file_name=zip_file_name, region=region)
 app.synth()

--- a/agents-for-bedrock/use-case-examples/text-2-sql-agent-cdk-enhanced/app.py
+++ b/agents-for-bedrock/use-case-examples/text-2-sql-agent-cdk-enhanced/app.py
@@ -190,13 +190,7 @@ class MyStack(Stack):
             api_schema=api_schema)
         
         agent.add_action_group(action_group)
-        
-        # agent.add_action_group(
-        #     description="Actions for getting the database schema and querying the Athena database for sample data or final query",
-        #     action_group_executor=action_group_function,
-        #     action_group_state="ENABLED",
-        #     api_schema=api_schema
-        # )
+       
         
          # IAM Role for Agent
         agent_role = iam.Role(self, "AgentRole",

--- a/agents-for-bedrock/use-case-examples/text-2-sql-agent-cdk-enhanced/cdk.json
+++ b/agents-for-bedrock/use-case-examples/text-2-sql-agent-cdk-enhanced/cdk.json
@@ -1,0 +1,3 @@
+{
+    "app": "python3 app.py"
+}

--- a/agents-for-bedrock/use-case-examples/text-2-sql-agent-cdk-enhanced/claude_3.py
+++ b/agents-for-bedrock/use-case-examples/text-2-sql-agent-cdk-enhanced/claude_3.py
@@ -1,0 +1,216 @@
+import base64
+import json
+import logging
+
+import boto3
+from botocore.exceptions import ClientError
+
+logger = logging.getLogger(__name__)
+
+def invoke_claude_3_with_text(prompt):
+        """
+        Invokes Anthropic Claude 3 Sonnet to run an inference using the input
+        provided in the request body.
+
+        :param prompt: The prompt that you want Claude 3 to complete.
+        :return: Inference response from the model.
+        """
+
+        # # Initialize the Amazon Bedrock runtime client
+        # client = self.client or boto3.client(
+        #     service_name="bedrock-runtime", region_name="us-east-1"
+        # )
+        client = boto3.client(service_name="bedrock-runtime", region_name="us-east-1")
+
+        # Invoke Claude 3 with the text prompt
+        model_id = "anthropic.claude-3-sonnet-20240229-v1:0"
+
+        try:
+            response = client.invoke_model(
+                modelId=model_id,
+                body=json.dumps(
+                    {
+                        "anthropic_version": "bedrock-2023-05-31",
+                        "max_tokens": 4096,
+                        "messages": [
+                            {
+                                "role": "user",
+                                "content": [{"type": "text", "text": prompt}],
+                            }
+                        ],
+                    }
+                ),
+            )
+
+            # Process and print the response
+            result = json.loads(response.get("body").read())
+            input_tokens = result["usage"]["input_tokens"]
+            output_tokens = result["usage"]["output_tokens"]
+            output_list = result.get("content", [])
+
+            #print("Invocation details:")
+            #print(f"- The input length is {input_tokens} tokens.")
+            #print(f"- The output length is {output_tokens} tokens.")
+
+            #print(f"- The model returned {len(output_list)} response(s):")
+            for output in output_list:
+                #print(output["text"])
+                final_result=output["text"]
+            return final_result
+        except ClientError as err:
+                    logger.error(
+                        "Couldn't invoke Claude 3 Sonnet. Here's why: %s: %s",
+                        err.response["Error"]["Code"],
+                        err.response["Error"]["Message"],
+                    )
+                    raise
+
+
+
+# snippet-start:[python.example_code.bedrock-runtime.Claude3Wrapper.class]
+class Claude3Wrapper:
+    """Encapsulates Claude 3 model invocations using the Amazon Bedrock Runtime client."""
+
+    def __init__(self, client=None):
+        """
+        :param client: A low-level client representing Amazon Bedrock Runtime.
+                       Describes the API operations for running inference using Bedrock models.
+                       Default: None
+        """
+        self.client = client
+
+    # snippet-start:[python.example_code.bedrock-runtime.InvokeAnthropicClaude3Text]
+    def invoke_claude_3_with_text(self, prompt):
+        """
+        Invokes Anthropic Claude 3 Sonnet to run an inference using the input
+        provided in the request body.
+
+        :param prompt: The prompt that you want Claude 3 to complete.
+        :return: Inference response from the model.
+        """
+
+        # Initialize the Amazon Bedrock runtime client
+        client = self.client or boto3.client(
+            service_name="bedrock-runtime", region_name="us-east-1"
+        )
+
+        # Invoke Claude 3 with the text prompt
+        model_id = "anthropic.claude-3-sonnet-20240229-v1:0"
+
+        try:
+            response = client.invoke_model(
+                modelId=model_id,
+                body=json.dumps(
+                    {
+                        "anthropic_version": "bedrock-2023-05-31",
+                        "max_tokens": 4096,
+                        "messages": [
+                            {
+                                "role": "user",
+                                "content": [{"type": "text", "text": prompt}],
+                            }
+                        ],
+                        "temperature": .01,
+                    }
+                ),
+            )
+
+            # Process and print the response
+            result = json.loads(response.get("body").read())
+            input_tokens = result["usage"]["input_tokens"]
+            output_tokens = result["usage"]["output_tokens"]
+            output_list = result.get("content", [])
+
+            print("Invocation details:")
+            print(f"- The input length is {input_tokens} tokens.")
+            print(f"- The output length is {output_tokens} tokens.")
+
+            print(f"- The model returned {len(output_list)} response(s):")
+            for output in output_list:
+                print(output["text"])
+
+            return result
+
+        except ClientError as err:
+            logger.error(
+                "Couldn't invoke Claude 3 Sonnet. Here's why: %s: %s",
+                err.response["Error"]["Code"],
+                err.response["Error"]["Message"],
+            )
+            raise
+
+    # snippet-end:[python.example_code.bedrock-runtime.InvokeAnthropicClaude3Text]
+
+    # snippet-start:[python.example_code.bedrock-runtime.InvokeAnthropicClaude3Multimodal]
+    def invoke_claude_3_multimodal(self, prompt, base64_image_data):
+        """
+        Invokes Anthropic Claude 3 Sonnet to run a multimodal inference using the input
+        provided in the request body.
+
+        :param prompt:            The prompt that you want Claude 3 to use.
+        :param base64_image_data: The base64-encoded image that you want to add to the request.
+        :return: Inference response from the model.
+        """
+
+        # Initialize the Amazon Bedrock runtime client
+        client = self.client or boto3.client(
+            service_name="bedrock-runtime", region_name="us-east-1"
+        )
+
+        # Invoke the model with the prompt and the encoded image
+        model_id = "anthropic.claude-3-sonnet-20240229-v1:0"
+        request_body = {
+            "anthropic_version": "bedrock-2023-05-31",
+            "max_tokens": 2048,
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": prompt,
+                        },
+                        {
+                            "type": "image",
+                            "source": {
+                                "type": "base64",
+                                "media_type": "image/png",
+                                "data": base64_image_data,
+                            },
+                        },
+                    ],
+                }
+            ],
+        }
+
+        try:
+            response = client.invoke_model(
+                modelId=model_id,
+                body=json.dumps(request_body),
+            )
+
+            # Process and print the response
+            result = json.loads(response.get("body").read())
+            input_tokens = result["usage"]["input_tokens"]
+            output_tokens = result["usage"]["output_tokens"]
+            output_list = result.get("content", [])
+
+            print("Invocation details:")
+            print(f"- The input length is {input_tokens} tokens.")
+            print(f"- The output length is {output_tokens} tokens.")
+
+            print(f"- The model returned {len(output_list)} response(s):")
+            for output in output_list:
+                print(output["text"])
+
+            return result
+        except ClientError as err:
+            logger.error(
+                "Couldn't invoke Claude 3 Sonnet. Here's why: %s: %s",
+                err.response["Error"]["Code"],
+                err.response["Error"]["Message"],
+            )
+            raise
+
+    # snippet-end:[python.example_code.bedrock-runtime.InvokeAnthropicClaude3Multimodal]
+

--- a/agents-for-bedrock/use-case-examples/text-2-sql-agent-cdk-enhanced/claude_3.py
+++ b/agents-for-bedrock/use-case-examples/text-2-sql-agent-cdk-enhanced/claude_3.py
@@ -16,10 +16,6 @@ def invoke_claude_3_with_text(prompt):
         :return: Inference response from the model.
         """
 
-        # # Initialize the Amazon Bedrock runtime client
-        # client = self.client or boto3.client(
-        #     service_name="bedrock-runtime", region_name="us-east-1"
-        # )
         client = boto3.client(service_name="bedrock-runtime", region_name="us-east-1")
 
         # Invoke Claude 3 with the text prompt

--- a/agents-for-bedrock/use-case-examples/text-2-sql-agent-cdk-enhanced/lambda/agent/index.py
+++ b/agents-for-bedrock/use-case-examples/text-2-sql-agent-cdk-enhanced/lambda/agent/index.py
@@ -1,0 +1,177 @@
+import boto3
+import os
+import re
+import json
+import gzip
+from io import BytesIO
+
+outputLocation = os.environ['outputLocation']
+database_name =  os.environ['glue_database_name']
+region = os.environ['region']
+bucket_name= os.environ['bucket_name']
+def get_schema():
+    try:
+        glue_client = boto3.client('glue') 
+    
+        #database_name = 'thehistoryofbaseball' 
+        
+        table_schema_list=[]
+        response = glue_client.get_tables(DatabaseName=database_name)
+        print(response)
+        table_names = [table['Name'] for table in response['TableList']]
+        for table_name in table_names:
+            response = glue_client.get_table(DatabaseName=database_name, Name=table_name)
+            columns = response['Table']['StorageDescriptor']['Columns']
+            schema = {column['Name']: column['Type'] for column in columns}
+            table_schema_list.append({"Table: {}".format(table_name): 'Schema: {}'.format(schema)})
+    except Exception as e:
+        print(f"Error: {str(e)}")
+    return table_schema_list
+
+
+
+
+def correct_query(query):
+    import re
+
+   
+
+    return query
+
+
+def execute_athena_query(query):
+    # Initialize Athena client
+    athena_client = boto3.client('athena', region_name=region)
+
+    # Start query execution
+    response = athena_client.start_query_execution(
+        QueryString=query,
+        QueryExecutionContext={
+            'Database': database_name
+        },
+        ResultConfiguration={
+            'OutputLocation': outputLocation
+        }
+    )
+
+    # Get query execution ID
+    query_execution_id = response['QueryExecutionId']
+    print(f"Query Execution ID: {query_execution_id}")
+
+    # Wait for the query to complete
+    response_wait = athena_client.get_query_execution(QueryExecutionId=query_execution_id)
+
+    while response_wait['QueryExecution']['Status']['State'] in ['QUEUED', 'RUNNING']:
+        print("Query is still running...")
+        response_wait = athena_client.get_query_execution(QueryExecutionId=query_execution_id)
+
+    # Check if the query completed successfully
+    if response_wait['QueryExecution']['Status']['State'] == 'SUCCEEDED':
+        print("Query succeeded!")
+
+        # Get query results
+        query_results = athena_client.get_query_results(QueryExecutionId=query_execution_id)
+
+        # Extract and return the result data
+        return extract_result_data(query_results)
+
+    else:
+        print("Query failed!")
+        return None
+
+def extract_result_data(query_results):
+    #Return a cleaned response to the agent
+    result_data = []
+
+    # Extract column names
+    column_info = query_results['ResultSet']['ResultSetMetadata']['ColumnInfo']
+    column_names = [column['Name'] for column in column_info]
+
+    # Extract data rows
+    for row in query_results['ResultSet']['Rows']:
+        data = [item['VarCharValue'] for item in row['Data']]
+        result_data.append(dict(zip(column_names, data)))
+
+    return result_data
+
+def compress_data(data):
+    json_data = json.dumps(data)
+    if len(json_data.encode('utf-8')) > 25000:
+        out = BytesIO()
+        with gzip.GzipFile(fileobj=out, mode='wb') as gz:
+            gz.write(json_data.encode('utf-8'))
+        compressed_data = out.getvalue()
+        return compressed_data, True
+    return json_data.encode('utf-8'), False
+
+def save_to_s3(data, key):
+    s3_client = boto3.client('s3', region_name=region)
+    s3_client.put_object(Bucket=bucket_name, Key=key, Body=json.dumps(data))
+
+
+def lambda_handler(event, context):
+    result = None
+    headers = {}
+    is_compressed= False
+    if event['apiPath'] == "/getschema":
+        result = get_schema()
+        
+    
+    if event['apiPath'] == "/querydatabase":
+      
+        print(event['requestBody']['content']['application/json']['properties'])
+        query = event['requestBody']['content']['application/json']['properties'][0]['value']
+        
+        # Correct the query to handle special characters and spaces
+        original_query=query
+        corrected_query = correct_query(original_query)
+        print(f"Original Query: {original_query}")
+        print(f"Corrected Query: {corrected_query}")
+        
+        
+        result = execute_athena_query(corrected_query)
+        #result, is_compressed = compress_data(result)
+        
+    
+
+    if result:
+        print("Query Result:", result)
+       
+    else:
+        result="Query Failed."
+        
+        
+    if result and len(json.dumps(result)) > 25000:
+        key = f"Large_results/{database_name}/{context.aws_request_id}.json"
+        save_to_s3(result, key)
+        result = f"Data is large, saved to s3://{bucket_name}/{key}"
+       
+    response_body = {
+    'application/json': {
+        'body': json.dumps(result)
+    }
+    }  
+
+   
+    
+    action_response = {
+    'actionGroup': event['actionGroup'],
+    'apiPath': event['apiPath'],
+    'httpMethod': event['httpMethod'],
+    'httpStatusCode': 200 if result else 400,
+    'responseBody': response_body,
+    'headers': headers
+    }
+
+    
+    api_response = {
+        'messageVersion': '1.0', 
+        'response': action_response,
+        'sessionAttributes': event.get('sessionAttributes', {}),
+        'promptSessionAttributes': event.get('promptSessionAttributes', {})
+    }
+        
+    return api_response
+    
+    
+    

--- a/agents-for-bedrock/use-case-examples/text-2-sql-agent-cdk-enhanced/package-lock.json
+++ b/agents-for-bedrock/use-case-examples/text-2-sql-agent-cdk-enhanced/package-lock.json
@@ -1,0 +1,231 @@
+{
+    "name": "text-2-sql-agent-cdk-enhanced",
+    "lockfileVersion": 3,
+    "requires": true,
+    "packages": {
+        "": {
+            "dependencies": {
+                "aws-cdk-lib": "^2.38.0",
+                "constructs": "^10.0.0"
+            },
+            "devDependencies": {
+                "aws-cdk-lib": "2.38.0"
+            },
+            "peerDependencies": {
+                "aws-cdk-lib": "^2.38.0",
+                "constructs": "^10.0.0"
+            }
+        },
+        "node_modules/aws-cdk-lib": {
+            "version": "2.38.0",
+            "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.38.0.tgz",
+            "integrity": "sha512-OV2F4tcPgQH7P9wWYtS5m8hfO9Bup1FSkHUCzinW42oKTNk717CelkCIZ+aEzf3jdMjyeeNYEIEb++QTU4jdFQ==",
+            "bundleDependencies": [
+                "@balena/dockerignore",
+                "case",
+                "fs-extra",
+                "ignore",
+                "jsonschema",
+                "minimatch",
+                "punycode",
+                "semver",
+                "yaml"
+            ],
+            "dev": true,
+            "dependencies": {
+                "@balena/dockerignore": "^1.0.2",
+                "case": "1.6.3",
+                "fs-extra": "^9.1.0",
+                "ignore": "^5.2.0",
+                "jsonschema": "^1.4.1",
+                "minimatch": "^3.1.2",
+                "punycode": "^2.1.1",
+                "semver": "^7.3.7",
+                "yaml": "1.10.2"
+            },
+            "engines": {
+                "node": ">= 14.15.0"
+            },
+            "peerDependencies": {
+                "constructs": "^10.0.0"
+            }
+        },
+        "node_modules/aws-cdk-lib/node_modules/@balena/dockerignore": {
+            "version": "1.0.2",
+            "dev": true,
+            "inBundle": true,
+            "license": "Apache-2.0"
+        },
+        "node_modules/aws-cdk-lib/node_modules/at-least-node": {
+            "version": "1.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">= 4.0.0"
+            }
+        },
+        "node_modules/aws-cdk-lib/node_modules/balanced-match": {
+            "version": "1.0.2",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/aws-cdk-lib/node_modules/brace-expansion": {
+            "version": "1.1.11",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "node_modules/aws-cdk-lib/node_modules/case": {
+            "version": "1.6.3",
+            "dev": true,
+            "inBundle": true,
+            "license": "(MIT OR GPL-3.0-or-later)",
+            "engines": {
+                "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/aws-cdk-lib/node_modules/concat-map": {
+            "version": "0.0.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT"
+        },
+        "node_modules/aws-cdk-lib/node_modules/fs-extra": {
+            "version": "9.1.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "at-least-node": "^1.0.0",
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^6.0.1",
+                "universalify": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/aws-cdk-lib/node_modules/graceful-fs": {
+            "version": "4.2.10",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC"
+        },
+        "node_modules/aws-cdk-lib/node_modules/ignore": {
+            "version": "5.2.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 4"
+            }
+        },
+        "node_modules/aws-cdk-lib/node_modules/jsonfile": {
+            "version": "6.1.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "dependencies": {
+                "universalify": "^2.0.0"
+            },
+            "optionalDependencies": {
+                "graceful-fs": "^4.1.6"
+            }
+        },
+        "node_modules/aws-cdk-lib/node_modules/jsonschema": {
+            "version": "1.4.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/aws-cdk-lib/node_modules/lru-cache": {
+            "version": "6.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/aws-cdk-lib/node_modules/minimatch": {
+            "version": "3.1.2",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/aws-cdk-lib/node_modules/punycode": {
+            "version": "2.1.1",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/aws-cdk-lib/node_modules/semver": {
+            "version": "7.3.7",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "dependencies": {
+                "lru-cache": "^6.0.0"
+            },
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/aws-cdk-lib/node_modules/universalify": {
+            "version": "2.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 10.0.0"
+            }
+        },
+        "node_modules/aws-cdk-lib/node_modules/yallist": {
+            "version": "4.0.0",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC"
+        },
+        "node_modules/aws-cdk-lib/node_modules/yaml": {
+            "version": "1.10.2",
+            "dev": true,
+            "inBundle": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/constructs": {
+            "version": "10.3.0",
+            "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.3.0.tgz",
+            "integrity": "sha512-vbK8i3rIb/xwZxSpTjz3SagHn1qq9BChLEfy5Hf6fB3/2eFbrwt2n9kHwQcS0CPTRBesreeAcsJfMq2229FnbQ==",
+            "engines": {
+                "node": ">= 16.14.0"
+            }
+        }
+    }
+}

--- a/agents-for-bedrock/use-case-examples/text-2-sql-agent-cdk-enhanced/package.json
+++ b/agents-for-bedrock/use-case-examples/text-2-sql-agent-cdk-enhanced/package.json
@@ -1,0 +1,13 @@
+{
+    "peerDependencies": {
+      "aws-cdk-lib": "^2.38.0",
+      "constructs": "^10.0.0"
+    },
+    "devDependencies": {
+      "aws-cdk-lib": "2.38.0"
+    },
+    "dependencies": {
+        "aws-cdk-lib": "^2.38.0",
+        "constructs": "^10.0.0"
+      }
+  }

--- a/agents-for-bedrock/use-case-examples/text-2-sql-agent-cdk-enhanced/requirements.txt
+++ b/agents-for-bedrock/use-case-examples/text-2-sql-agent-cdk-enhanced/requirements.txt
@@ -1,0 +1,6 @@
+bedrock-agent
+boto3
+pandas
+cdklabs.generative-ai-cdk-constructs
+aws-cdk.aws-lambda-python-alpha
+botocore

--- a/agents-for-bedrock/use-case-examples/text-2-sql-agent-cdk-enhanced/setup.sh
+++ b/agents-for-bedrock/use-case-examples/text-2-sql-agent-cdk-enhanced/setup.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+
+# Upgrade pip
+pip install --upgrade pip
+pip install --upgrade boto3
+
+# Install nvm if it is not already installed
+if ! command -v nvm &> /dev/null; then
+  echo "nvm not found, installing..."
+  curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.3/install.sh | bash
+  # Load nvm into the current shell session
+  export NVM_DIR="$HOME/.nvm"
+  [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+  [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"
+fi
+
+# Load nvm into the current shell session
+export NVM_DIR="$HOME/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"
+
+# Install Node.js version 18 using nvm
+nvm install 18
+nvm use 18
+
+
+# Install and update AWS CDK globally
+npm install -g aws-cdk@latest
+npm update -g aws-cdk
+
+# Install Node.js project dependencies
+npm install
+
+# Install Python dependencies
+pip install -r requirements.txt

--- a/agents-for-bedrock/use-case-examples/text-2-sql-agent-cdk-enhanced/text_to_sql_openapi_schema.json
+++ b/agents-for-bedrock/use-case-examples/text-2-sql-agent-cdk-enhanced/text_to_sql_openapi_schema.json
@@ -1,0 +1,89 @@
+{
+    "openapi": "3.0.0",
+    "info": {
+        "title": "Database schema look up and query APIs",
+        "version": "1.0.0",
+        "description": "APIs for looking up database table schemas and making queries to database tables."
+    },
+    "paths": {
+        "/getschema": {
+            "get": {
+                "summary": "Get a list of all tables and their schema in the database",
+                "description": "Get the list of all tables and their schema. Return all the table and schema information.",
+                "operationId": "getschema",
+                "responses": {
+                    "200": {
+                        "description": "Gets the list of table names and their schemas in the database",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "Table": {
+                                                "type": "string",
+                                                "description": "The name of the table in the database."
+                                            },
+                                            "Schema": {
+                                                "type": "string",
+                                                "description": "The schema of the table in the database. Contains all columns needed for making queries."
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/querydatabase": {
+            "post": {
+                "summary": "API to send SQL query to the database table",
+                "description": "Send a SQL query to the database table to retrieve information pertaining to the users question . The API takes in only one SQL query at a time, sends the SQL statement and returns the query results from the table. This API should be called for each SQL query to a database table.",
+                "operationId": "querydatabase",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "type": "object",
+                                "properties": {
+                                    "query": {
+                                        "type": "string",
+                                        "description": "SQL statement to query database table."
+                                    }
+                                },
+                                "required": [
+                                    "query"
+                                ]
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Query sent successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "responsebody": {
+                                            "type": "string",
+                                            "description": "The query response from the database."
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad request. One or more required fields are missing or invalid."
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION

add text-2-sql-agent-cdk-enhanced


Differences from  text-2-sql-agent Repo (https://github.com/aws-samples/amazon-bedrock-samples/tree/main/agents-for-bedrock/use-case-examples/text-2-sql-agent)
This repository enhances the original Text to SQL Bedrock Agent with the following improvements:

- Uses AWS CDK to build the necessary infrastructure.
- Works with any dataset: simply create a folder with all your data in CSV files, create a zip file of this folder, place it in the "Data" directory, and the code will automatically extract and upload the files, generating the necessary instructions. Provide the zip file name at the time of deployment (cdk deploy --profile XXX --context zip_file_name=EV_WA.zip).
- If the answer is large, it creates a file in S3 and points the user to the S3 location.