### PR TITLE
Add invoke_model api for llama3 import model

### DIFF
--- a/custom_models/import_models/llama-3/llama3-sftt-llama3-fine-tuning.ipynb
+++ b/custom_models/import_models/llama-3/llama3-sftt-llama3-fine-tuning.ipynb
@@ -656,6 +656,88 @@
    "source": [
     "![SageMaker Finetuning Log](./images/llama3-ft-SageMakerTrainingLog.png)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "754f4e64",
+   "metadata": {},
+   "source": [
+    "### Invoke the imported model using Bedrock API's"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6d029869",
+   "metadata": {},
+   "source": [
+    "!pip install boto3 botocore --upgrade --quiet"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0e6c55ff",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import boto3\n",
+    "import json\n",
+    "from botocore.exceptions import ClientError"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "13860684",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "client = boto3.client(\"bedrock-runtime\", region_name=\"us-west-2\")\n",
+    "\n",
+    "model_id = \"<<replace with the imported bedrock model arn>>\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7eb1a71e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def call_invoke_model_and_print(native_request):\n",
+    "    request = json.dumps(native_request)\n",
+    "\n",
+    "    try:\n",
+    "        # Invoke the model with the request.\n",
+    "        response = client.invoke_model(modelId=model_id, body=request)\n",
+    "        model_response = json.loads(response[\"body\"].read())\n",
+    "\n",
+    "        response_text = model_response[\"generation\"]\n",
+    "        print(response_text)\n",
+    "    except (ClientError, Exception) as e:\n",
+    "        print(f\"ERROR: Can't invoke '{model_id}'. Reason: {e}\")\n",
+    "        exit(1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d532d4f0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "prompt = \"Write a paragraph about a cat and his owner but start each sentence with a new letter following alphabetical order\"\n",
+    "formatted_prompt = f\"{system_prompt}{prompt}\"\n",
+    "\n",
+    "native_request = {\n",
+    "    \"prompt\": formatted_prompt,\n",
+    "    \"max_gen_len\": 512,\n",
+    "    \"top_p\": 0.9,\n",
+    "    \"temperature\": 0.91\n",
+    "}\n",
+    "\n",
+    "call_invoke_model_and_print(native_request)"
+   ]
   }
  ],
  "metadata": {

--- a/custom_models/import_models/llama-3/llama3-sftt-llama3-fine-tuning.ipynb
+++ b/custom_models/import_models/llama-3/llama3-sftt-llama3-fine-tuning.ipynb
@@ -666,9 +666,11 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "6d029869",
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c0da7b24",
    "metadata": {},
+   "outputs": [],
    "source": [
     "!pip install boto3 botocore --upgrade --quiet"
    ]


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add Bedrock invoke_model API examples for Llama3 Bedrock custom import model.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
