### PR TITLE
Update TIG Instant Customization Notebook

### DIFF
--- a/multimodal/Titan Image Generator/Instant Customization/Introduction to Amazon Titan Image Generator Instant Customization Feature.ipynb
+++ b/multimodal/Titan Image Generator/Instant Customization/Introduction to Amazon Titan Image Generator Instant Customization Feature.ipynb
@@ -221,60 +221,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2cb57797",
-   "metadata": {},
-   "source": [
-    "Please note that, `at this moment` if you want to provide more than 1 reference images, `all the reference images need to have the same size.` \n",
-    "You can use the following code to resize your input images:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "id": "75570cf7",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Original image size: (900, 1000)\n",
-      "Resized image size: (900, 1000)\n"
-     ]
-    }
-   ],
-   "source": [
-    "from PIL import Image\n",
-    "import os\n",
-    "\n",
-    "# Set the path to your image file\n",
-    "image_path = \"Data/smila.jpg\"\n",
-    "\n",
-    "# Check if the image file exists\n",
-    "if os.path.exists(image_path):\n",
-    "    # Load the image using Pillow\n",
-    "    image = Image.open(image_path)\n",
-    "\n",
-    "    # Get the original image size\n",
-    "    original_size = image.size\n",
-    "    print(f\"Original image size: {original_size}\")\n",
-    "\n",
-    "    # Define the new size\n",
-    "    new_size = (900, 1000)\n",
-    "\n",
-    "    # Resize the image\n",
-    "    resized_image = image.resize(new_size)\n",
-    "\n",
-    "    print(f\"Resized image size: {resized_image.size}\")\n",
-    "    resized_image.save(image_path)\n",
-    "else:\n",
-    "    print(\"Image file not found.\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "9a456f7c",
    "metadata": {},
    "source": [


### PR DESCRIPTION
Service team confirmed that it is no longer necessary for all input reference images to have the same size

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
