### PR TITLE
Updating labs 1 and 3 to address hallucination when user prompts to reserve days off for an employee

### DIFF
--- a/agents-for-bedrock/features-examples/01-create-agent-with-function-definition/01-create-agent-with-function-definition.ipynb
+++ b/agents-for-bedrock/features-examples/01-create-agent-with-function-definition/01-create-agent-with-function-definition.ipynb
@@ -661,7 +661,7 @@
     "    },\n",
     "    {\n",
     "        'name': 'reserve_vacation_time',\n",
-    "        'description': 'reserve vacation time for a specific employee',\n",
+    "        'description': 'reserve vacation time for a specific employee - you need all parameters to reserve vacation time',\n",
     "        'parameters': {\n",
     "            \"employee_id\": {\n",
     "                \"description\": \"the id of the employee for which time off will be reserved\",\n",

--- a/agents-for-bedrock/features-examples/03-create-agent-with-return-of-control/03-create-agent-with-return-of-control.ipynb
+++ b/agents-for-bedrock/features-examples/03-create-agent-with-return-of-control/03-create-agent-with-return-of-control.ipynb
@@ -310,7 +310,7 @@
     "    },\n",
     "    {\n",
     "        'name': 'reserve_vacation_time',\n",
-    "        'description': 'reserve vacation time for a specific employee',\n",
+    "        'description': 'reserve vacation time for a specific employee - you need all parameters to reserve vacation time',\n",
     "        'parameters': {\n",
     "            \"employee_id\": {\n",
     "                \"description\": \"the id of the employee for which time off will be reserved\",\n",


### PR DESCRIPTION
To address hallucination issue when users prompts to reserve days off for an employee, I have updated the "reserve_vacation_time" function description. It now states to use all parameters and now asks the user for "start date" and "end date" information if missing in their prompt.
