### PR TITLE
Fix Llama3 PEFT Merge dtype

### DIFF
--- a/custom_models/import_models/llama-3/llama3-sftt-llama3-fine-tuning.ipynb
+++ b/custom_models/import_models/llama-3/llama3-sftt-llama3-fine-tuning.ipynb
@@ -474,7 +474,7 @@
     "        model = AutoPeftModelForCausalLM.from_pretrained(\n",
     "            training_args.output_dir,\n",
     "            low_cpu_mem_usage=True,\n",
-    "            torch_dtype=torch_dtype\n",
+    "            torch_dtype=torch.float16 # loading in other precision types gives errors.\n",
     "        )\n",
     "        # Merge LoRA and base model and save\n",
     "        model = model.merge_and_unload()\n",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
When Merging the model adapters for llama 3 using any other torch dtype besides float16 is giving NAN values in the model.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
