### PR TITLE
added agent eval in lab 5

### DIFF
--- a/agents-for-bedrock/features-examples/05-create-agent-with-knowledge-base-and-action-group/05-create-agent-with-knowledge-base-and-action-group.ipynb
+++ b/agents-for-bedrock/features-examples/05-create-agent-with-knowledge-base-and-action-group/05-create-agent-with-knowledge-base-and-action-group.ipynb
@@ -1516,6 +1516,76 @@
   },
   {
    "cell_type": "markdown",
+   "id": "073f0489-bcb8-4329-b16f-afafaf6f4819",
+   "metadata": {},
+   "source": [
+    "## Agent Evaluation Framework - Testing the Agent\n",
+    "\n",
+    "The [Agent Evaluation Framework](https://awslabs.github.io/agent-evaluation/) offers a structured approach for assessing the performance, accuracy, and effectiveness of Bedrock Agents.\n",
+    "\n",
+    "The next steps are optional, and show you how to write test cases and run them against the Bedrock Agent."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "830155fb-59f0-4f7d-b3c5-3cada968e6ba",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "!python3 -m pip install agent-evaluation==0.2.0 # Installs the agent-evaluation framework tool\n",
+    "\n",
+    "!which agenteval # Checks the agent evaluation framework is properly installed"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fff61ec1-68b9-4d50-8082-09884f979862",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "- The following sections prepare the `agenteval.yml` file by providing the Agent ID created with this notebook into line 5. In the `agenteval.yml` file you will find the different test cases defined to test the Agent."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0fd95939-2da3-4743-bc4e-fd53b6c9ed63",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "agent_id # Prints the Agent ID for reference here\n",
+    "\n",
+    "!sed -i 's/<AGENT_ID>/{agent_id}/g' agenteval.yml"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "54f7f2f7-5369-4b60-86c8-2e0269724d83",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Run the defined test cases that are part of the repo (i.e. the agenteval.yml file)\n",
+    "\n",
+    "!agenteval run"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "96af7a1c-400b-4904-bd39-6069b56c7eda",
+   "metadata": {},
+   "source": [
+    "- The output above shows the results of the testing evaluation. You can find a detailed report about the tests evaluation under the following generated file: `agenteval_summary.md.` You can preview it by right-clicking and select open with -> markdown preview\n",
+    "  \n",
+    "- You will notice that some new files have been generated as well once the test have been executed (e.g. `check_number_of_vacation.json`), where you will find the detailed traces from the test conversation between the test User and the test Agent."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "8ebf4438-1f48-4642-a57c-530a16815064",
    "metadata": {
     "pycharm": {
@@ -2184,9 +2254,9 @@
   ],
   "instance_type": "ml.t3.medium",
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3 (Data Science 3.0)",
    "language": "python",
-   "name": "python3"
+   "name": "python3__SAGEMAKER_INTERNAL__arn:aws:sagemaker:us-east-1:081325390199:image/sagemaker-data-science-310-v1"
   },
   "language_info": {
    "codemirror_mode": {
@@ -2198,7 +2268,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.12"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/agents-for-bedrock/features-examples/05-create-agent-with-knowledge-base-and-action-group/05-create-agent-with-knowledge-base-and-action-group.ipynb
+++ b/agents-for-bedrock/features-examples/05-create-agent-with-knowledge-base-and-action-group/05-create-agent-with-knowledge-base-and-action-group.ipynb
@@ -1519,7 +1519,7 @@
    "id": "073f0489-bcb8-4329-b16f-afafaf6f4819",
    "metadata": {},
    "source": [
-    "## Agent Evaluation Framework - Testing the Agent\n",
+    "## Agent Evaluation Framework - Testing the Agent (Optional)\n",
     "\n",
     "The [Agent Evaluation Framework](https://awslabs.github.io/agent-evaluation/) offers a structured approach for assessing the performance, accuracy, and effectiveness of Bedrock Agents.\n",
     "\n",
@@ -1547,7 +1547,8 @@
     "tags": []
    },
    "source": [
-    "- The following sections prepare the `agenteval.yml` file by providing the Agent ID created with this notebook into line 5. In the `agenteval.yml` file you will find the different test cases defined to test the Agent."
+    "- The following sections prepare the `agenteval.yml` file by providing the Agent ID created with this notebook into line 5. In the `agenteval.yml` file you will find the different test cases defined to test the Agent.\n",
+    "- As of writing, only Claude 3 Sonnet is supported as an evaluator. The Claude-3 model specified in the yml file refers to Claude 3 Sonnet."
    ]
   },
   {

--- a/agents-for-bedrock/features-examples/05-create-agent-with-knowledge-base-and-action-group/agenteval.yml
+++ b/agents-for-bedrock/features-examples/05-create-agent-with-knowledge-base-and-action-group/agenteval.yml
@@ -11,9 +11,9 @@ tests:
     steps:
     - Ask agent for a the dishes in the dinner menu that contains chicken.
   make_and_check_booking:
-    expected_results:
-    - The agent returns with the booking ID
-    - The booking details are.. Name Anna, Number of guests 2, Date 16 July, Time 7pm
     steps:
     - Ask agent to make a booking for Anna, 2 people, 16 July at 7pm.
     - Using the booking ID, check for the booking details
+    expected_results:
+    - The agent returns with the booking ID
+    - The booking details are.. Name Anna, Number of guests 2, Date 16 July, Time 7pm

--- a/agents-for-bedrock/features-examples/05-create-agent-with-knowledge-base-and-action-group/agenteval.yml
+++ b/agents-for-bedrock/features-examples/05-create-agent-with-knowledge-base-and-action-group/agenteval.yml
@@ -1,0 +1,19 @@
+evaluator:
+  model: claude-3
+target:
+  bedrock_agent_alias_id: {agent_id}
+  bedrock_agent_id: none
+  type: bedrock-agent
+tests:
+  check_for_chicken_dinner:
+    expected_results:
+    - The agent returns a list of dishes from the dinner menu that contains chicken.
+    steps:
+    - Ask agent for a the dishes in the dinner menu that contains chicken.
+  make_and_check_booking:
+    expected_results:
+    - The agent returns with the booking ID
+    - The booking details are.. Name Anna, Number of guests 2, Date 16 July, Time 7pm
+    steps:
+    - Ask agent to make a booking for Anna, 2 people, 16 July at 7pm.
+    - Using the booking ID, check for the booking details


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Added a short agent evaluation portion in the end of lab 5 to introduce the concept of Agent Evaluation. The changes are exactly as per discussed what can be added in the 1st iteration, as we further discuss how to make more integrations with agent eval framework.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
