### PR TITLE
Bugfix: bootstrap env before deploying blueprint stacks

### DIFF
--- a/agents-for-bedrock/agent-blueprint-templates/blueprints.sh
+++ b/agents-for-bedrock/agent-blueprint-templates/blueprints.sh
@@ -111,7 +111,10 @@ deploy_stack() {
   read -p "Verify the stack in cdk.out. Are you sure you want to deploy the $stack stack? (y/n) " -n 1 -r
   echo
   if [[ $REPLY =~ ^[Yy]$ ]]; then
-    echo "Deploying $stack stack..."
+    echo "Bootstrapping account $accountId in region $region."
+    cdk bootstrap aws://$accountId/$region
+
+    echo "Deploying $stack stack."
     cdk deploy
   else
     echo "Deployment canceled."
@@ -134,11 +137,11 @@ case "$1" in
     deploy_stack "$2"
     ;;
   *)
-    echo "Usage: $0 <command>"
+    echo "Usage: $0 <command> [parameters]"
     echo "Commands:"
     echo "  init      Install project dependencies"
     echo "  ls        List available stacks"
-    echo "  deploy    Deploy a stack"
+    echo "  deploy <value>   Deploy a blueprint stack"
     exit 1
     ;;
 esac


### PR DESCRIPTION
*Issue #, if available:*

Deployment fails for a new account/region if the environment is not bootstrapped:
```
❌ Deployment failed: Error: AgentWithFunctionDefinitionStack: SSM parameter /cdk-bootstrap/hnb659fds/version not found. Has the environment been bootstrapped? Please run 'cdk bootstrap' (see https://docs.aws.amazon.com/cdk/latest/guide/bootstrapping.html)
    at Deployments.validateBootstrapStackVersion (/usr/local/lib/node_modules/aws-cdk/lib/index.js:454:12210)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
```

However since we initialize the blueprint stacks dynamically through the script they are not available in the vanilla application leading to following error:
```
$cdk bootstrap
No stack to deploy
This app contains no stacks
```

*Description of changes:*
Since bootstrapping has no overhead, run `cdk bootstrap` each time we deploy a stack. From [docs](https://docs.aws.amazon.com/cdk/v2/guide/bootstrapping-env.html):
> You must bootstrap each AWS environment before you deploy into the environment. We recommend that you proactively bootstrap each environment that you plan to use. You can do this before you plan on actually deploying CDK apps into the environment.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
