### PR TITLE
Cross region inference bugfix

### DIFF
--- a/inference/cross-region-inference/Getting_started_with_Cross-region_Inference.ipynb
+++ b/inference/cross-region-inference/Getting_started_with_Cross-region_Inference.ipynb
@@ -52,6 +52,7 @@
    "outputs": [],
    "source": [
     "# Make sure you have AWS credentials or AWS profile setup before running this cell\n",
+    "account_id = boto3.client('sts').get_caller_identity().get('Account')\n",
     "region_name = 'us-east-1'\n",
     "bedrock_client = boto3.client('bedrock', region_name=region_name)\n",
     "bedrock_runtime = boto3.client('bedrock-runtime', region_name=region_name)"
@@ -163,9 +164,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You can observe that using the same API and only the change in model id you can expect similar behavior.\n",
+    "You can observe that using the same API and only the change in model ID you can expect similar behavior.\n",
     "\n",
-    "It is also possible to use `inferenceProfileArn` with the `Converse` API:"
+    "It is also possible to use a full ARN in place of the model ID:"
    ]
   },
   {
@@ -174,10 +175,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "inferenceProfileArn = 'arn:aws:bedrock:us-east-1::inference-profile/us.anthropic.claude-3-sonnet-20240229-v1:0'\n",
+    "inference_profile_id = \"us.anthropic.claude-3-sonnet-20240229-v1:0\"\n",
+    "inference_profile_arn = f\"arn:aws:bedrock:{region_name}:{account_id}:inference-profile/{inference_profile_id}\"\n",
     "\n",
     "response = bedrock_runtime.converse(\n",
-    "    modelId=inferenceProfileArn,\n",
+    "    modelId=inference_profile_arn,\n",
     "    system=[{\"text\": system_prompt}],\n",
     "    messages=[{\n",
     "        \"role\": \"user\",\n",

--- a/inference/cross-region-inference/Getting_started_with_Cross-region_Inference.ipynb
+++ b/inference/cross-region-inference/Getting_started_with_Cross-region_Inference.ipynb
@@ -29,8 +29,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#Start by installing the dependencies to ensure we have a recent version\n",
-    "!pip install --upgrade --force-reinstall boto3 botocore awscli\n",
+    "# Start by installing the dependencies to ensure we have a recent version\n",
+    "!pip install --quiet --upgrade --force-reinstall boto3 botocore awscli\n",
     "import boto3\n",
     "print(boto3.__version__)"
    ]
@@ -142,7 +142,7 @@
     "system_prompt = \"You are an expert on AWS services and always provide correct and concise answers.\"\n",
     "input_message = \"Should I be storing documents in Amazon S3 or EFS for cost effective applications?\"\n",
     "modelId = ('Foundation Model', 'anthropic.claude-3-haiku-20240307-v1:0')\n",
-    "inferenceProfileId = ('Inference Profile','us.anthropic.claude-3-haiku-20240307-v1:0')\n",
+    "inferenceProfileId = ('Inference Profile', 'us.anthropic.claude-3-haiku-20240307-v1:0')\n",
     "\n",
     "for inference_type, id in [modelId, inferenceProfileId]:\n",
     "    start = time()\n",
@@ -225,7 +225,7 @@
     "accept = 'application/json'\n",
     "contentType = 'application/json'\n",
     "modelId = ('Foundation Model', 'anthropic.claude-3-sonnet-20240229-v1:0')\n",
-    "inferenceProfileId = ('Inference Profile','us.anthropic.claude-3-sonnet-20240229-v1:0')\n",
+    "inferenceProfileId = ('Inference Profile', 'us.anthropic.claude-3-sonnet-20240229-v1:0')\n",
     "for inference_type, id in [modelId, inferenceProfileId]:\n",
     "    start = time()\n",
     "    response = bedrock_runtime.invoke_model(body=body, modelId=id, accept=accept, contentType=contentType)\n",
@@ -249,7 +249,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install -q langchain_aws langchain_community"
+    "!pip install --quiet langchain_aws langchain_community"
    ]
   },
   {


### PR DESCRIPTION
*Description of changes:*

This PR addresses a small bug where the ARN for the Inference Profile was missing the account ID. With this change, the ARN is now correctly constructed using the `region_name` and the `account_id`.

Also contains minor cleanup for easier readability.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
