### PR TITLE
Issue #311 resolved

### DIFF
--- a/agents-and-function-calling/bedrock-agents/features-examples/01-create-agent-with-function-definition/01-create-agent-with-function-definition.ipynb
+++ b/agents-and-function-calling/bedrock-agents/features-examples/01-create-agent-with-function-definition/01-create-agent-with-function-definition.ipynb
@@ -434,7 +434,6 @@
     "        \"Statement\": [\n",
     "            {\n",
     "                \"Effect\": \"Allow\",\n",
-    "                \"Action\": \"bedrock:InvokeModel\",\n",
     "                \"Principal\": {\n",
     "                    \"Service\": \"lambda.amazonaws.com\"\n",
     "                },\n",

--- a/agents-and-function-calling/bedrock-agents/features-examples/02-create-agent-with-api-schema/02-create-agent-with-api-schema.ipynb
+++ b/agents-and-function-calling/bedrock-agents/features-examples/02-create-agent-with-api-schema/02-create-agent-with-api-schema.ipynb
@@ -226,7 +226,6 @@
     "        \"Statement\": [\n",
     "            {\n",
     "                \"Effect\": \"Allow\",\n",
-    "                \"Action\": \"bedrock:InvokeModel\",\n",
     "                \"Principal\": {\n",
     "                    \"Service\": \"lambda.amazonaws.com\"\n",
     "                },\n",

--- a/agents-and-function-calling/bedrock-agents/features-examples/06-prompt-and-session-attributes/06-prompt-and-session-attributes.ipynb
+++ b/agents-and-function-calling/bedrock-agents/features-examples/06-prompt-and-session-attributes/06-prompt-and-session-attributes.ipynb
@@ -458,7 +458,6 @@
     "        \"Statement\": [\n",
     "            {\n",
     "                \"Effect\": \"Allow\",\n",
-    "                \"Action\": \"bedrock:InvokeModel\",\n",
     "                \"Principal\": {\n",
     "                    \"Service\": \"lambda.amazonaws.com\"\n",
     "                },\n",

--- a/agents-and-function-calling/bedrock-agents/features-examples/07-advanced-prompts-and-custom-parsers/07-custom-prompt-and-lambda-parsers.ipynb
+++ b/agents-and-function-calling/bedrock-agents/features-examples/07-advanced-prompts-and-custom-parsers/07-custom-prompt-and-lambda-parsers.ipynb
@@ -435,7 +435,6 @@
     "        \"Statement\": [\n",
     "            {\n",
     "                \"Effect\": \"Allow\",\n",
-    "                \"Action\": \"bedrock:InvokeModel\",\n",
     "                \"Principal\": {\n",
     "                    \"Service\": \"lambda.amazonaws.com\"\n",
     "                },\n",

--- a/agents-and-function-calling/bedrock-agents/features-examples/08-create-agent-with-guardrails/agent.py
+++ b/agents-and-function-calling/bedrock-agents/features-examples/08-create-agent-with-guardrails/agent.py
@@ -94,7 +94,6 @@ class AgentsForAmazonBedrock:
                 "Statement": [
                     {
                         "Effect": "Allow",
-                        "Action": "bedrock:InvokeModel",
                         "Principal": {
                             "Service": "lambda.amazonaws.com"
                         },

--- a/agents-and-function-calling/bedrock-agents/features-examples/09-create-agent-with-memory/09-create-agent-with-memory.ipynb
+++ b/agents-and-function-calling/bedrock-agents/features-examples/09-create-agent-with-memory/09-create-agent-with-memory.ipynb
@@ -40,10 +40,10 @@
    "execution_count": null,
    "id": "c603ce06-61d8-4236-92e8-883e0d49cfea",
    "metadata": {
-    "tags": [],
     "pycharm": {
      "name": "#%%\n"
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -69,10 +69,10 @@
    "execution_count": null,
    "id": "48daaac3-aeb2-439b-8648-f9a088b4f40c",
    "metadata": {
-    "tags": [],
     "pycharm": {
      "name": "#%%\n"
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -101,10 +101,10 @@
    "execution_count": null,
    "id": "5255655e-d83e-416a-a459-83590483d22b",
    "metadata": {
-    "tags": [],
     "pycharm": {
      "name": "#%%\n"
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -122,10 +122,10 @@
    "execution_count": null,
    "id": "593be615-dab2-4084-a518-ee905113bfc7",
    "metadata": {
-    "tags": [],
     "pycharm": {
      "name": "#%%\n"
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -151,10 +151,10 @@
    "execution_count": null,
    "id": "67883027-bbb5-42a6-955d-0aa019a8e4b3",
    "metadata": {
-    "tags": [],
     "pycharm": {
      "name": "#%%\n"
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -183,10 +183,10 @@
    "execution_count": null,
    "id": "f6af5cd4-33b8-40c3-9d99-1790540eb60c",
    "metadata": {
-    "tags": [],
     "pycharm": {
      "name": "#%%\n"
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -201,10 +201,10 @@
    "execution_count": null,
    "id": "0dcb5332-c035-435a-91e5-838ec95d9a7d",
    "metadata": {
-    "tags": [],
     "pycharm": {
      "name": "#%%\n"
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -246,10 +246,10 @@
    "execution_count": null,
    "id": "476a71a8-61c1-4dd4-89a1-6ac59f38cd3d",
    "metadata": {
-    "tags": [],
     "pycharm": {
      "name": "#%%\n"
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -363,10 +363,10 @@
    "execution_count": null,
    "id": "e9a5ad9c-7fc0-4844-bc89-c32e409dd327",
    "metadata": {
-    "tags": [],
     "pycharm": {
      "name": "#%%\n"
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -377,7 +377,6 @@
     "        \"Statement\": [\n",
     "            {\n",
     "                \"Effect\": \"Allow\",\n",
-    "                \"Action\": \"bedrock:InvokeModel\",\n",
     "                \"Principal\": {\n",
     "                    \"Service\": \"lambda.amazonaws.com\"\n",
     "                },\n",
@@ -422,10 +421,10 @@
    "execution_count": null,
    "id": "4db0472f-dfda-4085-8a44-89971f34c5a9",
    "metadata": {
-    "tags": [],
     "pycharm": {
      "name": "#%%\n"
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -465,10 +464,10 @@
    "execution_count": null,
    "id": "10ffd724-3d1b-4916-8513-466c5dd03fcc",
    "metadata": {
-    "tags": [],
     "pycharm": {
      "name": "#%%\n"
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -501,10 +500,10 @@
    "execution_count": null,
    "id": "83f3cf61-e65b-4c61-8a66-76bd5946eb32",
    "metadata": {
-    "tags": [],
     "pycharm": {
      "name": "#%%\n"
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -557,10 +556,10 @@
    "execution_count": null,
    "id": "6251ebaa-693d-4fee-b28c-2b0692d94ae5",
    "metadata": {
-    "tags": [],
     "pycharm": {
      "name": "#%%\n"
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -596,10 +595,10 @@
    "execution_count": null,
    "id": "0774ea09-6ccf-476d-b2bb-c8265b614f60",
    "metadata": {
-    "tags": [],
     "pycharm": {
      "name": "#%%\n"
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -629,10 +628,10 @@
    "execution_count": null,
    "id": "a99e5855-fe22-450b-889a-da73e44fdc30",
    "metadata": {
-    "tags": [],
     "pycharm": {
      "name": "#%%\n"
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -708,10 +707,10 @@
    "execution_count": null,
    "id": "d474b3e7-8501-48ed-82d1-f8a3792227a4",
    "metadata": {
-    "tags": [],
     "pycharm": {
      "name": "#%%\n"
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -737,10 +736,10 @@
    "execution_count": null,
    "id": "22feec4a-d3ec-48f6-9e33-e5a09f08701e",
    "metadata": {
-    "tags": [],
     "pycharm": {
      "name": "#%%\n"
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -765,10 +764,10 @@
    "execution_count": null,
    "id": "c739e041-9ea0-4eef-8151-d206e2fd9e37",
    "metadata": {
-    "tags": [],
     "pycharm": {
      "name": "#%%\n"
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -787,10 +786,10 @@
    "execution_count": null,
    "id": "a5cdfb72-e41c-4d78-ab12-ce8394574c17",
    "metadata": {
-    "tags": [],
     "pycharm": {
      "name": "#%%\n"
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -816,10 +815,10 @@
    "execution_count": null,
    "id": "e7094e7f-915a-4396-8d98-c3bfee3ccf1e",
    "metadata": {
-    "tags": [],
     "pycharm": {
      "name": "#%%\n"
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -834,10 +833,10 @@
    "execution_count": null,
    "id": "aae1ff1a",
    "metadata": {
-    "tags": [],
     "pycharm": {
      "name": "#%%\n"
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -887,10 +886,10 @@
    "execution_count": null,
    "id": "0f2ec6f4-fdd4-494c-b755-d27d7bbeb28d",
    "metadata": {
-    "tags": [],
     "pycharm": {
      "name": "#%%\n"
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -952,10 +951,10 @@
    "execution_count": null,
    "id": "4525b20b-e977-43a7-84fe-5dee0202e0fa",
    "metadata": {
-    "tags": [],
     "pycharm": {
      "name": "#%%\n"
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -985,10 +984,10 @@
    "execution_count": null,
    "id": "ca7a33c3-44f5-45d7-a880-7f6d33783c68",
    "metadata": {
-    "tags": [],
     "pycharm": {
      "name": "#%%\n"
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -1013,10 +1012,10 @@
    "execution_count": null,
    "id": "5895f94a-114b-4c6b-ba27-cab6889a458a",
    "metadata": {
-    "tags": [],
     "pycharm": {
      "name": "#%%\n"
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -1041,10 +1040,10 @@
    "execution_count": null,
    "id": "f7f07fa3-53da-4e19-950b-9603ee6067c7",
    "metadata": {
-    "tags": [],
     "pycharm": {
      "name": "#%%\n"
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -1070,10 +1069,10 @@
    "execution_count": null,
    "id": "c51f6c07-51ad-4a5e-b9ae-d31c9c3a49c2",
    "metadata": {
-    "tags": [],
     "pycharm": {
      "name": "#%%\n"
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -1099,10 +1098,10 @@
    "execution_count": null,
    "id": "6abe3019-ad8d-42dd-b98f-dc68e2235799",
    "metadata": {
-    "tags": [],
     "pycharm": {
      "name": "#%%\n"
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -1130,10 +1129,10 @@
    "execution_count": null,
    "id": "452522a9-5b53-45f4-b9ee-78fd6377e76c",
    "metadata": {
-    "tags": [],
     "pycharm": {
      "name": "#%%\n"
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -1146,10 +1145,10 @@
    "execution_count": null,
    "id": "0d2d2275-edd1-4439-82e3-a6a7cf356f7d",
    "metadata": {
-    "tags": [],
     "pycharm": {
      "name": "#%%\n"
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -1176,10 +1175,10 @@
    "execution_count": null,
    "id": "2a97a1f5-b0a6-4e36-a208-adad5626f165",
    "metadata": {
-    "tags": [],
     "pycharm": {
      "name": "#%%\n"
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -1206,10 +1205,10 @@
    "execution_count": null,
    "id": "a8e70350-0d69-4e6f-a236-35b9a8fcd684",
    "metadata": {
-    "tags": [],
     "pycharm": {
      "name": "#%%\n"
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -1238,10 +1237,10 @@
    "execution_count": null,
    "id": "4b3ef46d-299a-4777-bc76-c0ee594f485b",
    "metadata": {
-    "tags": [],
     "pycharm": {
      "name": "#%%\n"
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [
@@ -1274,10 +1273,10 @@
    "execution_count": null,
    "id": "c4c1a37d-f07a-4fbb-bb39-0a5b0ef8eca1",
    "metadata": {
-    "tags": [],
     "pycharm": {
      "name": "#%%\n"
-    }
+    },
+    "tags": []
    },
    "outputs": [],
    "source": [


### PR DESCRIPTION
*Issue #, if available:* #311

*Description of changes:*

Lambda for the action group is created with following policy document:

```
assume_role_policy_document = {
        "Version": "2012-10-17",
        "Statement": [
            {
                "Effect": "Allow",
                "Action": "bedrock:InvokeModel",
                "Principal": {
                    "Service": "lambda.amazonaws.com"
                },
                "Action": "sts:AssumeRole"
            }
        ]
    }
```

This policy has "Action": "bedrock:InvokeModel" which is not required.

Affected files and notebooks:

- agents-and-function-calling/bedrock-agents/features-examples/01-create-agent-with-function-definition/01-create-agent-with-function-definition.ipynb
- agents-and-function-calling/bedrock-agents/features-examples/02-create-agent-with-api-schema/02-create-agent-with-api-schema.ipynb
- agents-and-function-calling/bedrock-agents/features-examples/06-prompt-and-session-attributes/06-prompt-and-session-attributes.ipynb
- agents-and-function-calling/bedrock-agents/features-examples/07-advanced-prompts-and-custom-parsers/07-custom-prompt-and-lambda-parsers.ipynb
- agents-and-function-calling/bedrock-agents/features-examples/08-create-agent-with-guardrails/agent.py
- agents-and-function-calling/bedrock-agents/features-examples/09-create-agent-with-memory/09-create-agent-with-memory.ipynb

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
