### PR TITLE
Updated to install specific versions of crewai and crewai_tools

### DIFF
--- a/agents-and-function-calling/open-source-agents/crew.ai/Find a dream destination with CrewAI.ipynb
+++ b/agents-and-function-calling/open-source-agents/crew.ai/Find a dream destination with CrewAI.ipynb
@@ -27,7 +27,7 @@
    "metadata": {},
    "cell_type": "markdown",
    "source": [
-    "__!pip install boto3 botocore crewai crewai_tools duckduckgo-search langchain-community -q__\n",
+    "__!pip install boto3 botocore crewai==0.70.1 crewai_tools==0.12.1 duckduckgo-search langchain-community -q__\n",
     "\n",
     "We start by importing the necessary modules from the crewai and crewai_tools packages."
    ],


### PR DESCRIPTION
Had to use specific versions of crewai and crewai_tools as the latest versions was breaking the code. aws_bedrock as a memory embedding provider was failing.

*Issue #, if available:*

*Description of changes:*
Added version numbers.
