### PR TITLE
notebook for generating AWS Glue data catalog metadata

### DIFF
--- a/genai-use-cases/aws-glue-metadata-generation/how_to_generate_metadata_for_glue_data_catalog_w_bedrock.ipynb
+++ b/genai-use-cases/aws-glue-metadata-generation/how_to_generate_metadata_for_glue_data_catalog_w_bedrock.ipynb
@@ -1,0 +1,846 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "890fa32b-3332-412d-9034-256b2e7e9c5d",
+   "metadata": {},
+   "source": [
+    "# Use generative AI to enhance your technical metadata stored in AWS Glue Data Catalog"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ebf25b90-0ead-4acb-9491-c36c8b19e650",
+   "metadata": {},
+   "source": [
+    "## 1. Setup"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a1128ab5-80ee-48fc-a83f-15e78d5ee4c4",
+   "metadata": {},
+   "source": [
+    "In this section we will install the required dependecies. Ensure your SageMaker notebook role has access to \n",
+    "- AWS Glue \n",
+    "- Amazon Bedrock\n",
+    "- Amazon S3\n",
+    "\n",
+    "Enable model access for Bedrock. This notebook is using \n",
+    "- Anthropic Claude 3 - Sonnet \n",
+    "- Amazon Titan Text Embeddings V2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6c460869-ea02-4c59-afc5-f1158eb26d20",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install -U boto3==1.34.117\n",
+    "!pip install -U langchain==0.2.1\n",
+    "!pip install --upgrade --quiet  langchain-aws\n",
+    "!pip install jsonschema\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "978ed628-84c6-4940-97ca-0d05d3a05ab0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os, sys, json\n",
+    "import bedrock\n",
+    "import boto3 \n",
+    "import langchain\n",
+    "from langchain.llms.bedrock import Bedrock\n",
+    "from langchain.prompts import PromptTemplate\n",
+    "import logging\n",
+    "from datetime import date, datetime\n",
+    "import pprint \n",
+    "\n",
+    "module_path = \"..\"\n",
+    "sys.path.append(os.path.abspath(module_path))\n",
+    "logger = logging.getLogger(__name__)\n",
+    "\n",
+    "\n",
+    "# ---- ⚠️ Un-comment and edit the below lines as needed for your AWS setup ⚠️ ----\n",
+    "\n",
+    "os.environ[\"AWS_DEFAULT_REGION\"] = \"us-east-1\"  # E.g. \"us-east-1\"\n",
+    "# os.environ[\"AWS_PROFILE\"] = \"<YOUR_PROFILE>\"\n",
+    "# os.environ[\"BEDROCK_ASSUME_ROLE\"] = \"<YOUR_ROLE_ARN>\"  # E.g. \"arn:aws:...\"\n",
+    "GLUE_CRAWLER_ARN = 'ENTER_YOUR_GLUE_CRAWLER_IAM_ROLE_HERE'\n",
+    "\n",
+    "bedrock_client= bedrock.get_bedrock_client(\n",
+    "    assumed_role=os.environ.get(\"BEDROCK_ASSUME_ROLE\", None),\n",
+    "    region=os.environ.get(\"AWS_DEFAULT_REGION\", None)\n",
+    ")\n",
+    "\n",
+    "glue_client = boto3.client(\"glue\", region_name=\"us-east-1\")\n",
+    "\n",
+    "\n",
+    "model_id = \"anthropic.claude-3-sonnet-20240229-v1:0\"\n",
+    "embeddings_model_id= \"amazon.titan-embed-text-v2:0\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "65309422-ab33-4f95-884b-ee6498c986cf",
+   "metadata": {},
+   "source": [
+    "### Create S3 bucket"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "41151529-0027-4682-afb8-a173aec03dfe",
+   "metadata": {},
+   "source": [
+    "In this section we will create the S3 resources. This include an S3 bucket and files containing our test data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "525ce45d-39da-4906-93be-a11ce3e1b819",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import random\n",
+    "import string\n",
+    "s3_client = boto3.client('s3')\n",
+    "\n",
+    "# Define the prefix for the bucket name\n",
+    "bucket_prefix = 'aws-gen-ai-glue-metadata'\n",
+    "\n",
+    "# Generate a random string to append to the bucket name\n",
+    "random_suffix = ''.join(random.choices(string.ascii_lowercase + string.digits, k=10))\n",
+    "\n",
+    "# Construct the bucket name\n",
+    "bucket_name = f\"{bucket_prefix}-{random_suffix}\"\n",
+    "\n",
+    "# Create the S3 bucket\n",
+    "try:\n",
+    "    s3_client.create_bucket(Bucket=bucket_name)\n",
+    "    print(f\"Bucket '{bucket_name}' created successfully.\")\n",
+    "except Exception as e:\n",
+    "    print(f\"Error creating bucket: {e}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e6878c2a-0c4e-48f9-80a2-20445d56629b",
+   "metadata": {},
+   "source": [
+    "### Copy the files from the remote S3 bucket to the local bucket"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "23120850-f402-4951-89be-7b809e9b81cd",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Set the bucket name and prefix for the source files\n",
+    "source_bucket_name = 'awsglue-datasets'\n",
+    "source_prefix = 'examples/us-legislators/all/'\n",
+    "\n",
+    "# Set the destination bucket name\n",
+    "destination_bucket_name = bucket_name\n",
+    "\n",
+    "# List of folder names\n",
+    "folder_names = ['areas', 'countries', 'events', 'memberships', 'organizations', 'persons']\n",
+    "\n",
+    "# List of file names\n",
+    "file_names = ['areas.json', 'countries.json', 'events.json', 'memberships.json', 'organizations.json', 'persons.json']\n",
+    "\n",
+    "# Create the folders in the destination bucket\n",
+    "for folder_name in folder_names:\n",
+    "    s3_client.put_object(Bucket=destination_bucket_name, Key=(folder_name + '/'))\n",
+    "\n",
+    "# Copy the files to the corresponding folders\n",
+    "for folder_name, file_name in zip(folder_names, file_names):\n",
+    "    source_key = f\"{source_prefix}{file_name}\"\n",
+    "    destination_key = f\"{folder_name}/{file_name}\"\n",
+    "\n",
+    "    copy_source = {\n",
+    "        'Bucket': source_bucket_name,\n",
+    "        'Key': source_key\n",
+    "    }\n",
+    "\n",
+    "    s3_client.copy_object(\n",
+    "        CopySource=copy_source,\n",
+    "        Bucket=destination_bucket_name,\n",
+    "        Key=destination_key\n",
+    "    )\n",
+    "\n",
+    "print(\"Files copied successfully!\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "19a06235-7dc8-4718-806c-62159411bee0",
+   "metadata": {},
+   "source": [
+    "### Create AWS Glue Resources "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "62b52bff-61c3-438f-90d1-9cfcca722d24",
+   "metadata": {},
+   "source": [
+    "In this section we will create the AWS Glue resources. This include the Glue Database and the Glue Crawler. The table metadata will be automcatically updated by the crawler (this step might take a couple of minutes.) "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1f955d0a-6b76-481e-9dae-366590d5b3d9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "database = 'legislators'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4a68844e-f148-4331-ab56-abade220cb1b",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import time \n",
+    "Create the database\n",
+    "glue_client.create_database(DatabaseInput={'Name': database})\n",
+    "print(f\"AWS Glue database '{database}' created succesfully.\")\n",
+    "# Define the crawler configuration\n",
+    "crawler_name = 'my-s3-crawler'\n",
+    "role_arn = GLUE_CRAWLER_ARN\n",
+    "database_name = database\n",
+    "s3_target_path = 's3://' + bucket_name + '/'\n",
+    "\n",
+    "# Create the crawler\n",
+    "response = glue_client.create_crawler(\n",
+    "    Name=crawler_name,\n",
+    "    Role=role_arn,\n",
+    "    DatabaseName=database_name,\n",
+    "    Description='Crawler for S3 data',\n",
+    "    Targets={\n",
+    "        'S3Targets': [\n",
+    "            {'Path': s3_target_path}\n",
+    "        ]\n",
+    "    }\n",
+    ")\n",
+    "time.sleep(5)\n",
+    "print(f\"AWS Glue Crawler '{crawler_name}' created succesfully.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7120e6d0-d326-479a-8f1c-d4e4e6f45dbd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Run the Glue Crawler. This step is going to take a few seconds to complete. \n",
+    "response = glue_client.start_crawler(\n",
+    "    Name=crawler_name\n",
+    ")\n",
+    "print(f\"AWS Glue Crawler '{crawler_name}' started.\")\n",
+    "time.sleep(5)\n",
+    "state_previous = None\n",
+    "while True:\n",
+    "    response_get = glue_client.get_crawler(Name=crawler_name)\n",
+    "    state = response_get[\"Crawler\"][\"State\"]\n",
+    "    if state != state_previous:\n",
+    "        state_previous = state\n",
+    "    if state == \"READY\":  # Other known states: RUNNING, STOPPING\n",
+    "        break\n",
+    "    time.sleep(10)\n",
+    "\n",
+    "print(f\"AWS Glue Crawler '{crawler_name}' finished.\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "885d4d34-328f-4e51-a96e-add8b036088d",
+   "metadata": {},
+   "source": [
+    "## 2. Inspect the AWS Glue data catalog"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "996e6be8-7239-40db-bce5-8bb522dc8117",
+   "metadata": {},
+   "source": [
+    "Once the Crawlers is completed, we should be able to see our tables. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7819cf23-5e14-4b13-973c-a7dc56107569",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from botocore.exceptions import ClientError\n",
+    "\n",
+    "def get_alltables(database):\n",
+    "    tables = []\n",
+    "    get_tables_paginator = glue_client.get_paginator('get_tables')\n",
+    "    for page in get_tables_paginator.paginate(DatabaseName=database):\n",
+    "        tables.extend(page['TableList'])\n",
+    "    return tables"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1e79a8c8-5e9a-4a35-9a3c-cc830bea71e6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def json_serial(obj):\n",
+    "\n",
+    "    if isinstance(obj, (datetime, date)):\n",
+    "        return obj.isoformat()\n",
+    "    raise TypeError (\"Type %s not serializable\" % type(obj))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3061a506-577f-48a2-b797-09998a6caf28",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "database_tables =  get_alltables(database)\n",
+    "for table in database_tables:\n",
+    "    print(f\"Table: {table['Name']}\")\n",
+    "    print(f\"Columns: {[col['Name'] for col in table['StorageDescriptor']['Columns']]}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "439ac045-0e25-48ed-acfc-391867fc57e3",
+   "metadata": {},
+   "source": [
+    "# 3. Generate table metadata descriptions with Anthropic Claude 3 using Amazon Bedrock and Langchain"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e95cb60d-79fa-459d-a74f-1ff36f239e0b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "glue_data_catalog = json.dumps(get_alltables(database),default=json_serial)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "89850c4b-931d-4eea-b71a-1e9f7c5732d4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain_core.output_parsers import StrOutputParser\n",
+    "from langchain_core.prompts import ChatPromptTemplate\n",
+    "from botocore.config import Config\n",
+    "from langchain_aws import ChatBedrock\n",
+    "\n",
+    "model_kwargs ={ \n",
+    "    \"temperature\": 0.5, # You can increase or decrease this value depending on the amount of randomness you want injected into the response. A value closer to 1 increases the amount of randomness.\n",
+    "    \"top_p\": 0.999\n",
+    "}\n",
+    "\n",
+    "model = ChatBedrock(\n",
+    "    client = bedrock_client,\n",
+    "    model_id=model_id,\n",
+    "    model_kwargs=model_kwargs\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9dfc6671-9041-4a22-8c41-b0cd1c521bdf",
+   "metadata": {},
+   "source": [
+    "### Generate metadata for a specific database table"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "381beb4c-9239-46d4-a1af-06fdf496b6bd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "table = \"persons\"\n",
+    "response_get_table = glue_client.get_table( DatabaseName = database, Name = table ) \n",
+    "pprint.pp(response_get_table)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bb3223cb-a76f-49c0-94cb-c2f9334be3a9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "user_msg_template_table=\"\"\"\n",
+    "I'd like to you create metadata descriptions for the table called {table} in your AWS Glue data catalog. Please follow these steps:\n",
+    "1. Review the data catalog carefully\n",
+    "2. Use all the data catalog information to generate the table description\n",
+    "3. If a column is a primary key or foreign key to another table mention it in the description.\n",
+    "4. In your response, reply with the entire JSON object for the table {table}\n",
+    "5. Remove the DatabaseName, CreatedBy, IsRegisteredWithLakeFormation, CatalogId,VersionId,IsMultiDialectView,CreateTime, UpdateTime. \n",
+    "6. Write the table description in the Description attribute\n",
+    "7. List all the table columns under the attribute \"StorageDescriptor\" and then the attribute Columns. Add Location, InputFormat, and SerdeInfo\n",
+    "8. For each column in the StorageDescriptor, add the attribute \"Comment\".  If a table uses a composite primary key, then the order of a given column in a table’s primary key is listed in parentheses following the column name.\n",
+    "9. Your response must be a valid JSON object.\n",
+    "10. Ensure that the data is accurately represented and properly formatted within the JSON structure. The resulting JSON table should provide a clear, structured overview of the information presented in the original text.\n",
+    "11. If  you cannot think of an accurate description of a column, say 'not available'\n",
+    "Here is the data catalog json in <glue_data_catalog></glue_data_catalog> tags.\n",
+    "\n",
+    "<glue_data_catalog>\n",
+    "{data_catalog}\n",
+    "</glue_data_catalog>\n",
+    "\n",
+    "Here is some additional information about the database in <notes></notes> tags.\n",
+    "<notes>\n",
+    "Typically foreign key columns consist of the name of the table plus the id suffix\n",
+    "<notes>\n",
+    "\"\"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4f2c1663-a232-4fd6-a253-b0dae4c32dcc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "messages = [\n",
+    "    (\"system\", \"You are a helpful assistant\"),\n",
+    "    (\"user\", user_msg_template_table),\n",
+    "]\n",
+    "\n",
+    "prompt = ChatPromptTemplate.from_messages(messages)\n",
+    "\n",
+    "chain = prompt | model | StrOutputParser()\n",
+    "\n",
+    "# # Chain Invoke\n",
+    "TableInputFromLLM = chain.invoke({\"data_catalog\": {glue_data_catalog}, \"table\":table})\n",
+    "print(TableInputFromLLM)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e9c3c047-4057-46c3-a891-7e9c77244ddc",
+   "metadata": {},
+   "source": [
+    "### Update the AWS Glue Data Catalog "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "903c1b33-5478-4be4-becf-dffe7eb19f79",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# We will validate the LLM response to ensure that it matches the Table input JSON schema as expected by the AWS Glue API. \n",
+    "# This validation code can only used as a starting point and it should be extended with additional validations for your use case. \n",
+    "# Documentation: https://python-jsonschema.readthedocs.io/en/stable/ \n",
+    "\n",
+    "from jsonschema import validate\n",
+    "\n",
+    "schema_table_input = {\n",
+    "    \"type\": \"object\", \n",
+    "    \"properties\" : {\n",
+    "            \"Name\" : {\"type\" : \"string\"},\n",
+    "            \"Description\" : {\"type\" : \"string\"},\n",
+    "            \"StorageDescriptor\" : {\n",
+    "            \"Columns\" : {\"type\" : \"array\"},\n",
+    "            \"Location\" : {\"type\" : \"string\"} ,\n",
+    "            \"InputFormat\": {\"type\" : \"string\"} ,\n",
+    "            \"SerdeInfo\": {\"type\" : \"object\"}\n",
+    "        }\n",
+    "    }\n",
+    "}\n",
+    "validate(instance=json.loads(TableInputFromLLM), schema=schema_table_input)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4300633b-57de-41bf-a402-8debabb9863f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = glue_client.update_table(DatabaseName=database, TableInput= json.loads(TableInputFromLLM) )\n",
+    "print(f\"Table {table} metadata updated!\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "07021766-ecce-48e0-8dad-bac2a67b4b54",
+   "metadata": {},
+   "source": [
+    "## 4. Improve meta-data descriptions by adding external documentation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7219b23c-60e7-4828-813f-a3b57457b10e",
+   "metadata": {},
+   "source": [
+    "### Ingestion workflow"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2815cb3f-9ba0-404c-a3cc-315d9594b45a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain.docstore.document import Document\n",
+    "from langchain.document_loaders import TextLoader\n",
+    "from langchain.embeddings import BedrockEmbeddings\n",
+    "from langchain.text_splitter import CharacterTextSplitter\n",
+    "from langchain.vectorstores import FAISS"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d0035f31-802d-44f3-a4e7-61d8b4ec5e73",
+   "metadata": {},
+   "source": [
+    "### Download the data from EveryPolitician.com "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "309d52d7-47f3-4fda-ab6f-ec8f34723579",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from langchain_community.document_loaders import AsyncHtmlLoader\n",
+    "# We will use an HTML Community loader to load the external documentation stored on HTLM \n",
+    "urls = [\"http://www.popoloproject.com/specs/person.html\", \"http://docs.everypolitician.org/data_structure.html\",'http://www.popoloproject.com/specs/organization.html','http://www.popoloproject.com/specs/membership.html','http://www.popoloproject.com/specs/area.html']\n",
+    "loader = AsyncHtmlLoader(urls)\n",
+    "docs = loader.load()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5b5cc1da-6886-47cd-91f1-4e07fcbc45c7",
+   "metadata": {},
+   "source": [
+    "Let's take a look at some of the content that was loaded"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3ec61e96-fe32-4130-aedf-95d6b4ccf754",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "docs[0].page_content[0:1000]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d90371f3-9fe6-4be1-a7db-768735993ada",
+   "metadata": {},
+   "source": [
+    "Next, we split the downloaded content into chunks"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dda0cdd3-ae85-4317-a156-24208bd951d4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "text_splitter = CharacterTextSplitter(\n",
+    "    separator='\\n',\n",
+    "    chunk_size=1000,\n",
+    "    chunk_overlap=200,\n",
+    "\n",
+    ")\n",
+    "split_docs = text_splitter.split_documents(docs)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ae6585ea-0580-48ab-bec3-71421dc1a2d0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "embedding_model = BedrockEmbeddings(\n",
+    "    client=bedrock_client,\n",
+    "    model_id=embeddings_model_id\n",
+    ")\n",
+    "vs = FAISS.from_documents(split_docs, embedding_model)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a8075c69-c7c6-4211-a1bc-82999f6441ff",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "search_results = vs.similarity_search(\n",
+    "    'What standards are used in the dataset?', k=2\n",
+    ")\n",
+    "print(search_results[0].page_content)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7f9ababf-6777-45b2-8bcc-45a966def77f",
+   "metadata": {},
+   "source": [
+    "### Query Worfklow"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3c4fe8c1-18aa-4733-b504-772c38521daa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from operator import itemgetter\n",
+    "from langchain_core.callbacks import BaseCallbackHandler\n",
+    "from typing import Dict, List, Any\n",
+    "\n",
+    "\n",
+    "\n",
+    "class PromptHandler(BaseCallbackHandler):\n",
+    "    def on_llm_start( self, serialized: Dict[str, Any], prompts: List[str], **kwargs: Any) -> Any:\n",
+    "        output = \"\\n\".join(prompts)\n",
+    "        print(output)\n",
+    "\n",
+    "\n",
+    "\n",
+    "system = \"You are a helpful assistant. You do not generate any harmful content.\"\n",
+    "# specify a user message\n",
+    "user_msg_rag = \"\"\"\n",
+    "\n",
+    "Here is the guidance document you should reference when answering the user: \n",
+    "<documentation>{context}</documentation>\n",
+    "\n",
+    "I'd like to you create metadata descriptions for the table called {table} in your AWS Glue data catalog. Please follow these steps:\n",
+    "1. Review the data catalog carefully\n",
+    "2. Use all the data catalog information and the <documentation> to generate the table description \n",
+    "3. If a column is a primary key or foreign key to another table mention it in the description.\n",
+    "4. In your response, reply with the entire JSON object for the table {table}\n",
+    "5. Remove the DatabaseName, CreatedBy, IsRegisteredWithLakeFormation, CatalogId,VersionId,IsMultiDialectView,CreateTime, UpdateTime. \n",
+    "6. Write the table description in the Description attribute. Ensure you use information from the <documentation> if possible.\n",
+    "7. List all the table columns under the attribute \"StorageDescriptor\" and then the attribute Columns. Add Location, InputFormat, and SerdeInfo\n",
+    "8. For each column in the StorageDescriptor, add the attribute \"Comment\". Ensure Name and Type are included.  If a table uses a composite primary key, then the order of a given column in a table’s primary key is listed in parentheses following the column name.\n",
+    "9. Your response must be a valid JSON object.\n",
+    "10. Ensure that the data is accurately represented and properly formatted within the JSON structure. The resulting JSON table should provide a clear, structured overview of the information presented in the original text.\n",
+    "11. If  you cannot think of an accurate description of a column, say 'not available'\n",
+    "\n",
+    "<glue_data_catalog>\n",
+    "{data_catalog}\n",
+    "</glue_data_catalog>\n",
+    "\n",
+    "Here is some additional information about the database in <notes></notes> tags.\n",
+    "<notes>\n",
+    "Typically foreign key columns consist of the name of the table plus the id suffix\n",
+    "<notes>\n",
+    "\"\"\"\n",
+    "\n",
+    "\n",
+    "messages = [\n",
+    "    (\"system\", system),\n",
+    "    (\"user\", user_msg_rag),\n",
+    "]\n",
+    "\n",
+    "prompt = ChatPromptTemplate.from_messages(messages)\n",
+    "\n",
+    "# Retrieve and Generate\n",
+    "retriever = vs.as_retriever(\n",
+    "    search_type=\"similarity\",\n",
+    "    search_kwargs={\"k\": 3},\n",
+    ")\n",
+    "\n",
+    "chain = (   \n",
+    "    {\"context\": itemgetter(\"table\")| retriever, \"data_catalog\": itemgetter(\"data_catalog\"), \"table\": itemgetter(\"table\")}\n",
+    "    | prompt\n",
+    "    | model\n",
+    "    | StrOutputParser()\n",
+    ")\n",
+    "\n",
+    "TableInputFromLLM = chain.invoke({\"data_catalog\":glue_data_catalog, \"table\":table})\n",
+    "print(TableInputFromLLM)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9e7ce232-0411-41b5-abb6-71141c467e8c",
+   "metadata": {},
+   "source": [
+    "### Update the AWS Glue Data Catalog"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c9e8b43e-d560-4fb5-8613-5e31c5260ef1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "validate(instance=json.loads(TableInputFromLLM), schema=schema_table_input)\n",
+    "\n",
+    "response = glue_client.update_table(DatabaseName=database, TableInput= json.loads(TableInputFromLLM) )\n",
+    "print(f\"Table {table} metadata updated!\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cda324f7-1664-4ce9-be0e-50b31b5bb193",
+   "metadata": {},
+   "source": [
+    "# Clean Up"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "33ec9e5d-9c64-429d-b5c1-fb74ec78e3b9",
+   "metadata": {},
+   "source": [
+    "### 1. Delete S3 bucket"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3e26892e-5a00-435e-9708-184ac564af98",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "s3 = boto3.resource('s3')\n",
+    "bucket = s3.Bucket(bucket_name)\n",
+    "bucket.objects.all().delete()\n",
+    "response = s3_client.delete_bucket(Bucket=bucket_name)\n",
+    "print(f\"Deleting bucket: {bucket_name}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "889de23a-90d0-4532-90d7-882ade5e5f4c",
+   "metadata": {},
+   "source": [
+    "### 2. Delete Glue Crawler"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c99d3f14-3e21-4fdf-8303-d615e33379ef",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = glue_client.delete_crawler(Name=crawler_name)\n",
+    "print(f\"Deleting crawler: {crawler_name}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4c1db80a-d4ca-4f1b-808a-30629f9b2b8b",
+   "metadata": {},
+   "source": [
+    "### 3. Delete AWS Glue Data Catalog tables and database "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9df81518-0741-41f3-8493-bf0febfd16f2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def delete_tables_in_database(database_name):\n",
+    "    # Get a list of all tables in the database\n",
+    "    tables = glue_client.get_tables(DatabaseName=database_name)['TableList']\n",
+    "\n",
+    "    # Iterate over the tables and delete each one\n",
+    "    for table in tables:\n",
+    "        table_name = table['Name']\n",
+    "        glue_client.delete_table(DatabaseName=database_name, Name=table_name)\n",
+    "        print(f\"Deleting table: {table_name}\")\n",
+    "\n",
+    "\n",
+    "delete_tables_in_database(database)\n",
+    "response = glue_client.delete_database(Name=database)\n",
+    "print(f\"Deleting database: {database}\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fec90a17-dd3b-452e-b6e0-1b2567efa978",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.14"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
New notebook that show cases how to use Amazon Bedrock to generate metadata for your AWS Glue data catalog

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
