### PR TITLE
Update create-customer-resources.sh with correct Bedrock Agents Lambda layer ZIP

### DIFF
--- a/agents-and-function-calling/bedrock-agents/use-case-examples/insurance-claim-lifecycle-automation/shell/create-customer-resources.sh
+++ b/agents-and-function-calling/bedrock-agents/use-case-examples/insurance-claim-lifecycle-automation/shell/create-customer-resources.sh
@@ -23,7 +23,7 @@ export BEDROCK_AGENTS_LAYER_ARN=$(aws lambda publish-layer-version \
     --layer-name bedrock-agents-and-function-calling \
     --description "Agents for Bedrock Layer" \
     --license-info "MIT" \
-    --content S3Bucket=${ARTIFACT_BUCKET_NAME},S3Key=agent/lambda/lambda-layer/bedrock-agents-and-function-calling-layer.zip \
+    --content S3Bucket=${ARTIFACT_BUCKET_NAME},S3Key=agent/lambda/lambda-layer/bedrock-agents-layer.zip \
     --compatible-runtimes python3.11 \
     --region ${AWS_REGION} \
     --query LayerVersionArn --output text)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

It looks like during the Refactoring bedrock agents folder changes, the following update was made to [create-customer-resources.sh](https://github.com/aws-samples/amazon-bedrock-samples/blob/main/agents-and-function-calling/bedrock-agents/use-case-examples/insurance-claim-lifecycle-automation/shell/create-customer-resources.sh):

export BEDROCK_AGENTS_LAYER_ARN=$(aws lambda publish-layer-version \
    --layer-name bedrock-agents-and-function-calling \
    --description "Agents for Bedrock Layer" \
    --license-info "MIT" \
    --content S3Bucket=${ARTIFACT_BUCKET_NAME},S3Key=agent/lambda/lambda-layer/bedrock-agents-and-function-calling-layer.zip \
    --compatible-runtimes python3.11 \
    --region ${AWS_REGION} \
    --query LayerVersionArn --output text)
    
Where bedrock-agents-and-function-calling-layer.zip is referenced as the Lambda layer package, but the actual zip file name (bedrock-agents-layer.zip) was not updated [here](https://github.com/aws-samples/amazon-bedrock-samples/blob/main/agents-and-function-calling/bedrock-agents/use-case-examples/insurance-claim-lifecycle-automation/agent/lambda/lambda-layer/bedrock-agents-layer.zip).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
