### PR TITLE
Update README.md

### DIFF
--- a/agents-and-function-calling/bedrock-agents/use-case-examples/README.md
+++ b/agents-and-function-calling/bedrock-agents/use-case-examples/README.md
@@ -2,15 +2,15 @@
 
 In this folder we provide you example implementations for the common [Amazon Bedrock Agents](https://aws.amazon.com/bedrock/agents/) use cases:
 
-1. [Retail Agent with Bedrock Agents](use-case-examples/agentsforbedrock-retailagent/README.md) - Agent designed to help with retail transactions
-1. [AI Powered Assistant for Investment Research](use-case-examples/ai-powered-assistant-for-investment-research/README.md) - Example agent combining multiple services to create the end-to-end customer experience in the Investment Research industry
-1. [Cost Explorer Agent](use-case-examples/cost-explorer-agent/README.md) - Agent that connects with AWS Cost Explorer data to support users optimizing AWS's costs
-1. [Customer Relationship Management Agent](use-case-examples/customer-relationship-management-agent/README.md) - Agent designed to help sales employees work with their customers 
-1. [Fine-grained-access-permission-agent](use-case-examples/fine-grained-access-permissions-agent/README.md) - Example agent using Session Attributes and Amazon Verified Permissions to implement fine-grained access permission to the Agent's action Group
-1. [HR Vacation Agent](use-case-examples/hr-assistant/README.md) - Agent to manage employee vacation time
-1. [Insurance Claim Lifecycle Automation Agent](use-case-examples/insurance-claim-lifecycle-automation/README.md) - Agent desired to help insurance employees working with claims
-1. [Marketing Agent](use-case-examples/marketing-agent/README.md) - Agent that supports enterprises creating marketing material
-1. [Product Review Agent](use-case-examples/product-review-agent/README.md) - Alternative Agent implementation that connects to Knowledge Bases via Action groups
-1. [Text to SQL Agent](use-case-examples/text-2-sql-agent/README.md) - Agent designed to generate and execute SQL queries using natural language
-1. [Text to SQL  Agent CDK Enhanced](use-case-examples/text-2-sql-agent-cdk-enhanced/Readme.md) - Agent designed to generate and execute SQL queries using natural language. This repository enhances the original Text to SQL Bedrock Agent with improvement on: using CDK, works with any dataset, works with super large answers.
+1. [Retail Agent with Bedrock Agents](agentsforbedrock-retailagent/README.md) - Agent designed to help with retail transactions
+1. [AI Powered Assistant for Investment Research](ai-powered-assistant-for-investment-research/README.md) - Example agent combining multiple services to create the end-to-end customer experience in the Investment Research industry
+1. [Cost Explorer Agent](cost-explorer-agent/README.md) - Agent that connects with AWS Cost Explorer data to support users optimizing AWS's costs
+1. [Customer Relationship Management Agent](customer-relationship-management-agent/README.md) - Agent designed to help sales employees work with their customers 
+1. [Fine-grained-access-permission-agent](fine-grained-access-permissions-agent/README.md) - Example agent using Session Attributes and Amazon Verified Permissions to implement fine-grained access permission to the Agent's action Group
+1. [HR Vacation Agent](hr-assistant/README.md) - Agent to manage employee vacation time
+1. [Insurance Claim Lifecycle Automation Agent](insurance-claim-lifecycle-automation/README.md) - Agent desired to help insurance employees working with claims
+1. [Marketing Agent](marketing-agent/README.md) - Agent that supports enterprises creating marketing material
+1. [Product Review Agent](product-review-agent/README.md) - Alternative Agent implementation that connects to Knowledge Bases via Action groups
+1. [Text to SQL Agent](text-2-sql-agent/README.md) - Agent designed to generate and execute SQL queries using natural language
+1. [Text to SQL  Agent CDK Enhanced](text-2-sql-agent-cdk-enhanced/Readme.md) - Agent designed to generate and execute SQL queries using natural language. This repository enhances the original Text to SQL Bedrock Agent with improvement on: using CDK, works with any dataset, works with super large answers.
 


### PR DESCRIPTION
Fix links to use case examples

*Issue #, if available:*

Links in the use-case-examples README lead to a 404 error, as the directory is repeated.

<img width="1448" alt="screenshot 2025-01-07 at 16 22 41" src="https://github.com/user-attachments/assets/0a4ee62f-429a-4169-8e27-6aa87f56c4ab" />

*Description of changes:*

Remove `use-case-examples/` from links, because the README.md is already in `use-case-examples` folder.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
