### PR TITLE
Adding instructions about potential timeouts when running batch inference

### DIFF
--- a/introduction-to-bedrock/batch_api/batch-inference-cloudtrail-analyzer.ipynb
+++ b/introduction-to-bedrock/batch_api/batch-inference-cloudtrail-analyzer.ipynb
@@ -662,6 +662,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Note\n",
+    "The model chosen for this tutorial is Haiku. If you find that the job has expired after 24 hours, this is because of high demand for batch inference jobs for this model. You can try increasing the `timeoutDurationInHours` to be greater than the default 24 hours, or you can try a different model."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Publish to SNS topic"
    ]
   },


### PR DESCRIPTION
Adding note about potential expiration of jobs stuck for more than 24h.

*Issue #, if available:*

*Description of changes:*
Adding a note in the notebook to explain how to handle the potential timeout.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
