### PR TITLE
Added LLMPerf script for DeepSeek with Bedrock CMI

### DIFF
--- a/custom-models/import_models/llama-3/benchmark-deepseek-r1-distill-llama-llmperf.ipynb
+++ b/custom-models/import_models/llama-3/benchmark-deepseek-r1-distill-llama-llmperf.ipynb
@@ -1,0 +1,1358 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "df07d6e0-a652-4c47-8f1b-48f08ff01e9d",
+   "metadata": {},
+   "source": [
+    "# Benchmarking Bedrock Custom Imported Models with LLMPerf and LiteLLM"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6aaff294-1095-469e-a8b5-f572e63e3e7e",
+   "metadata": {},
+   "source": [
+    "Amazon Bedrock [custom model import](https://aws.amazon.com/bedrock/custom-model-import/) allows users to deploy their own model weights, with Bedrock automatically optimizing deployment for performance, security, and scalability. While this feature accelerates and simplified the process, it raises a critical question: *how fast is this deployment?*\n",
+    "\n",
+    "This notebook provides a quick way to benchmark the performance of a Bedrock-managed deployment using [LLMPerf](https://github.com/ray-project/llmperf) (a lightweight benchmarking tool for large language models) and [LiteLLM](https://github.com/BerriAI/litellm) (a universal model gateway that abstracts API calls across different providers). This process is illustrated using [deepseek-ai/DeepSeek-R1-Distill-Llama-8B](https://huggingface.co/deepseek-ai/DeepSeek-R1-Distill-Llama-8B) as the imported model."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ffcfdaf0-dcbf-4af1-8812-d7126474e6ea",
+   "metadata": {},
+   "source": [
+    "**Notes**:\n",
+    "\n",
+    "- Use *SageMaker Distribution 1.12.10* as the image in an Amazon SageMaker Studio JupyterLab app.\n",
+    "- This notebook uses [deepseek-ai/DeepSeek-R1-Distill-Llama-8B](https://huggingface.co/deepseek-ai/DeepSeek-R1-Distill-Llama-8B). You will need more than 16 GB in instance memory and storage to download the model weights."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "55b25eb8-6624-4c7b-ae9a-971e549cc333",
+   "metadata": {},
+   "source": [
+    "### Installing dependencies"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "d9bf0eeb-539e-425f-934b-5adf86d80eba",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[31mERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.\n",
+      "grpcio-status 1.70.0 requires protobuf<6.0dev,>=5.26.1, but you have protobuf 4.25.6 which is incompatible.\u001b[0m\u001b[31m\n",
+      "\u001b[0m"
+     ]
+    }
+   ],
+   "source": [
+    "!pip install transformers sagemaker --quiet\n",
+    "!pip install boto3 huggingface huggingface_hub hf_transfer --upgrade --quiet"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "d2df2f31-b6ca-461b-b262-e7b177b2f0c5",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "sagemaker.config INFO - Not applying SDK defaults from location: /etc/xdg/sagemaker/config.yaml\n",
+      "sagemaker.config INFO - Not applying SDK defaults from location: /home/sagemaker-user/.config/sagemaker/config.yaml\n"
+     ]
+    }
+   ],
+   "source": [
+    "import sagemaker\n",
+    "import boto3\n",
+    "\n",
+    "boto_session = boto3.session.Session()\n",
+    "region = boto_session.region_name\n",
+    "\n",
+    "sess = sagemaker.Session()\n",
+    "sagemaker_session_bucket = None\n",
+    "if sagemaker_session_bucket is None and sess is not None:\n",
+    "    sagemaker_session_bucket = sess.default_bucket()\n",
+    "\n",
+    "try:\n",
+    "    role = sagemaker.get_execution_role()\n",
+    "except ValueError:\n",
+    "    iam = boto3.client('iam')\n",
+    "    role = iam.get_role(RoleName='sagemaker_execution_role')['Role']['Arn']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "51f673a6-b45f-498d-937c-beb4b347883f",
+   "metadata": {},
+   "source": [
+    "### Downloading model artifacts from Hugging Face"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "0c77b956-39ac-4d7d-88e8-f40fd6d6178c",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Directory 'deepseek-r1-distill-llama-8b' created.\n"
+     ]
+    }
+   ],
+   "source": [
+    "import os\n",
+    "\n",
+    "s3_prefix = \"deepseek-r1-distill-llama-8b\"\n",
+    "if not os.path.exists(s3_prefix):\n",
+    "    os.makedirs(s3_prefix)\n",
+    "    print(f\"Directory '{s3_prefix}' created.\")\n",
+    "else:\n",
+    "    print(f\"Directory '{s3_prefix}' already exists.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "469abbe3-d73a-4a90-9437-a7e02ad269f1",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "7792e3e8a0ba40c1900d82ea81da51ad",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Fetching 11 files:   0%|          | 0/11 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "fc7080c792be4e109800512e970e5a2c",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "model-00002-of-000002.safetensors:   0%|          | 0.00/7.39G [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "613a3b9a245d420c88da1fb7bacad5be",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "model-00001-of-000002.safetensors:   0%|          | 0.00/8.67G [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "1218ae084d544cef865ef884ca811d8f",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "config.json:   0%|          | 0.00/826 [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "940639d2ac2449f4860e3e707bff6de3",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       ".gitattributes:   0%|          | 0.00/1.52k [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "a98329c981a64723a50425887cbc5e99",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "figures%2Fbenchmark.jpg:   0%|          | 0.00/777k [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "1701299874134193a6fd0a9cb39aded1",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "README.md:   0%|          | 0.00/19.0k [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "10ffa89dc95b49308311b7a7a6574c1f",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "generation_config.json:   0%|          | 0.00/181 [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "500047b2e6b44385ac29bcf59d351bff",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "LICENSE:   0%|          | 0.00/1.06k [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "36e1b722cfd149bd84d068755503b8c7",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "model.safetensors.index.json:   0%|          | 0.00/24.2k [00:00<?, ?B/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "'/home/sagemaker-user/deepseek-r1-distill-llama-8b'"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import os\n",
+    "from huggingface_hub import snapshot_download\n",
+    "\n",
+    "hf_model_id = \"deepseek-ai/DeepSeek-R1-Distill-Llama-8B\"\n",
+    "os.environ[\"HF_HUB_ENABLE_HF_TRANSFER\"] = \"1\"\n",
+    "snapshot_download(\n",
+    "    repo_id=hf_model_id,\n",
+    "    local_dir=f\"./{s3_prefix}\"\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bf3f54c9-5c6e-4702-bca7-2f694aad7575",
+   "metadata": {},
+   "source": [
+    "### Uploading model artifacts to Amazon S3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "2b76e043-e7d6-45e6-a399-3716137cf61f",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Uploading files: 100%|██████████| 34/34 [00:41<00:00,  1.23s/it]\n"
+     ]
+    }
+   ],
+   "source": [
+    "import os\n",
+    "import time\n",
+    "import json\n",
+    "import boto3\n",
+    "from pathlib import Path\n",
+    "from tqdm import tqdm\n",
+    "\n",
+    "def upload_directory_to_s3(local_directory: str, bucket_name: str, s3_prefix: str):\n",
+    "    \"\"\"\n",
+    "    Upload files from a local directory to a user-defined prefix in an Amazon S3 bucket\n",
+    "    \"\"\"\n",
+    "    s3_client = boto3.client('s3')\n",
+    "    local_directory = Path(local_directory)\n",
+    "\n",
+    "    all_files = []\n",
+    "    # Walk the local directory\n",
+    "    for root, dirs, files in os.walk(local_directory):\n",
+    "        for filename in files:\n",
+    "            local_path = Path(root) / filename\n",
+    "            relative_path = local_path.relative_to(local_directory)\n",
+    "            s3_key = f\"{s3_prefix}/{relative_path}\"\n",
+    "            all_files.append((local_path, s3_key))\n",
+    "\n",
+    "    # Upload to S3\n",
+    "    for local_path, s3_key in tqdm(all_files, desc=\"Uploading files\"):\n",
+    "        try:\n",
+    "            s3_client.upload_file(str(local_path),bucket_name,s3_key)\n",
+    "        except Exception as e:\n",
+    "            print(f\"Error uploading {local_path}: {str(e)}\")\n",
+    "\n",
+    "upload_directory_to_s3(s3_prefix, sess.default_bucket(), s3_prefix)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d589ad49-cd4e-426f-a3b6-f39d0b3926cc",
+   "metadata": {},
+   "source": [
+    "## Importing model into Amazon Bedrock"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0306fda4-6a2e-483a-8a05-b037244aaddd",
+   "metadata": {},
+   "source": [
+    "### Create IAM role for model import job"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "c0c5e708-da8a-4cfd-89fd-b42d2b2b1437",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Role ARN: arn:aws:iam::447500535019:role/BedrockExecutionRole-2025-02-16-16-54-39-755\n"
+     ]
+    }
+   ],
+   "source": [
+    "import boto3\n",
+    "import json\n",
+    "from botocore.exceptions import ClientError\n",
+    "import logging\n",
+    "from sagemaker.utils import name_from_base\n",
+    "\n",
+    "logger = logging.getLogger(__name__)\n",
+    "\n",
+    "def create_bedrock_execution_role(role_name, account_id, region, s3_bucket):\n",
+    "    \"\"\"\n",
+    "    Creates an IAM role that allows Amazon Bedrock to assume the role and that grants S3 read permissions.\n",
+    "    \"\"\"\n",
+    "    iam = boto3.client('iam')\n",
+    "    trust_policy = {\n",
+    "        \"Version\": \"2012-10-17\",\n",
+    "        \"Statement\": [\n",
+    "            {\n",
+    "                \"Sid\": \"1\",\n",
+    "                \"Effect\": \"Allow\",\n",
+    "                \"Principal\": {\n",
+    "                    \"Service\": \"bedrock.amazonaws.com\"\n",
+    "                },\n",
+    "                \"Action\": \"sts:AssumeRole\",\n",
+    "                \"Condition\": {\n",
+    "                    \"StringEquals\": {\n",
+    "                        \"aws:SourceAccount\": account_id\n",
+    "                    },\n",
+    "                    \"ArnEquals\": {\n",
+    "                        \"aws:SourceArn\": f\"arn:aws:bedrock:{region}:{account_id}:model-import-job/*\"\n",
+    "                    }\n",
+    "                }\n",
+    "            }\n",
+    "        ]\n",
+    "    }\n",
+    "    s3_policy = {\n",
+    "        \"Version\": \"2012-10-17\",\n",
+    "        \"Statement\": [\n",
+    "            {\n",
+    "                \"Sid\": \"S3ReadAccess\",\n",
+    "                \"Effect\": \"Allow\",\n",
+    "                \"Action\": [\n",
+    "                    \"s3:GetObject\",\n",
+    "                    \"s3:ListBucket\"\n",
+    "                ],\n",
+    "                \"Resource\": [\n",
+    "                    f\"arn:aws:s3:::{s3_bucket}\",\n",
+    "                    f\"arn:aws:s3:::{s3_bucket}/*\"\n",
+    "                ],\n",
+    "                \"Condition\": {\n",
+    "                    \"StringEquals\": {\n",
+    "                        \"s3:ResourceAccount\": account_id\n",
+    "                    }\n",
+    "                }\n",
+    "            }\n",
+    "        ]\n",
+    "    }\n",
+    "\n",
+    "    try:\n",
+    "        response = iam.create_role(\n",
+    "            RoleName=role_name,\n",
+    "            AssumeRolePolicyDocument=json.dumps(trust_policy),\n",
+    "            Description=\"Execution role for Amazon Bedrock model import jobs\"\n",
+    "        )\n",
+    "        policy_name = f\"{role_name}-S3ReadAccess\"\n",
+    "        policy_response = iam.create_policy(\n",
+    "            PolicyName=policy_name,\n",
+    "            PolicyDocument=json.dumps(s3_policy),\n",
+    "            Description=\"Allows S3 read access for Bedrock execution role\"\n",
+    "        )\n",
+    "        iam.attach_role_policy(\n",
+    "            RoleName=role_name,\n",
+    "            PolicyArn=policy_response['Policy']['Arn']\n",
+    "        )\n",
+    "        logger.info(f\"Successfully created role: {role_name}\")\n",
+    "        return response['Role']\n",
+    "\n",
+    "    except ClientError as error:\n",
+    "        logger.error(f\"Failed to create role: {error}\")\n",
+    "        return None\n",
+    "\n",
+    "\n",
+    "bedrock_role_name = name_from_base(\"BedrockExecutionRole\")\n",
+    "aws_account = boto3.client('sts').get_caller_identity()['Account']\n",
+    "\n",
+    "bedrock_job_import_role = create_bedrock_execution_role(bedrock_role_name, aws_account, region, sagemaker_session_bucket)\n",
+    "if bedrock_job_import_role:\n",
+    "    print(f\"Role ARN: {bedrock_job_import_role['Arn']}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "6c866f93-415d-4b7c-98bd-0ec039e35a63",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Model import job created with ARN: arn:aws:bedrock:us-west-2:447500535019:model-import-job/1zul86qr8kpy\n"
+     ]
+    }
+   ],
+   "source": [
+    "bedrock = boto3.client('bedrock',region_name=region)\n",
+    "s3_uri = f's3://{sess.default_bucket()}/{s3_prefix}/' # S3 URI that contains th model artifacts\n",
+    "\n",
+    "from sagemaker.utils import name_from_base\n",
+    "\n",
+    "job_name = name_from_base(s3_prefix+\"-job\")\n",
+    "imported_model_name = name_from_base(s3_prefix+\"-model\")\n",
+    "\n",
+    "response = bedrock.create_model_import_job(\n",
+    "    jobName=job_name,\n",
+    "    importedModelName=imported_model_name,\n",
+    "    roleArn=bedrock_job_import_role['Arn'],\n",
+    "    modelDataSource={\n",
+    "        's3DataSource': {\n",
+    "            's3Uri': s3_uri\n",
+    "        }\n",
+    "    }\n",
+    ")\n",
+    "\n",
+    "job_Arn = response['jobArn']\n",
+    "print(f\"Model import job created with ARN: {job_Arn}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "395fe253-4799-4ff0-afdd-b1d3a05e3e5a",
+   "metadata": {},
+   "source": [
+    "The model import process can take ~10 min. The following cell will wait for you."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "f940dbfd-9153-4650-bfbc-4770e7777587",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Status: INPROGRESS\n",
+      "Status: INPROGRESS\n",
+      "Status: INPROGRESS\n",
+      "Status: INPROGRESS\n",
+      "Status: INPROGRESS\n",
+      "Status: INPROGRESS\n",
+      "Status: INPROGRESS\n",
+      "Status: INPROGRESS\n",
+      "Status: COMPLETED\n"
+     ]
+    }
+   ],
+   "source": [
+    "while True:\n",
+    "    response = bedrock.get_model_import_job(jobIdentifier=job_Arn)\n",
+    "    status = response['status'].upper()\n",
+    "    print(f\"Status: {status}\")\n",
+    "    if status in ['COMPLETED', 'FAILED']:\n",
+    "        break\n",
+    "    time.sleep(60)\n",
+    "\n",
+    "model_id = response['importedModelArn']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0f574e7e-c9b2-4664-855c-8073eb47f804",
+   "metadata": {},
+   "source": [
+    "Once the model has been imported, we may still have to give Bedrock a few minutes to initialize a serving container to handle our requests. If the model is not available yet, we will get an error message saying that the model is **not ready**."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "91dc4473-05d6-40f6-9fb8-8db4e36c54a8",
+   "metadata": {},
+   "source": [
+    "## Testing model inference with the InvokeModel API"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8eb67bc1-a20f-4cd6-983c-2878d183973c",
+   "metadata": {},
+   "source": [
+    "### Configuration to work with DeepSeek models"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "39c10444-d857-4de7-aebe-da8dcafdfef3",
+   "metadata": {},
+   "source": [
+    "DeepSeek models expect inputs to follow a specific format defined in the `tokenizer_config.json` file. This format ensures that the model receives prompts in the same structure that it was trained on. We are going to initialize a `tokenizer` and then use it to shape our model requests to ensure that the model sees prompts with the expected structure.\n",
+    "\n",
+    "We are also going to edit the configuration of the Bedrock runtime client to increase the timeout and the number of retries so we can work with long wait times and the potential unavailability of the model when the serving container is still being prepared."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "e367a5f6-0967-42eb-80aa-b640aed1eae2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from transformers import AutoTokenizer\n",
+    "import json\n",
+    "import boto3\n",
+    "from botocore.config import Config\n",
+    "from IPython.display import Markdown, display\n",
+    "\n",
+    "tokenizer = AutoTokenizer.from_pretrained(hf_model_id)\n",
+    "\n",
+    "session = boto3.Session()\n",
+    "client = session.client(\n",
+    "    service_name='bedrock-runtime',\n",
+    "    region_name=region,\n",
+    "    config=Config(\n",
+    "        connect_timeout=300,\n",
+    "        read_timeout=300,\n",
+    "        retries={'max_attempts': 3}\n",
+    "    )\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b766c7d0-ea9c-40b2-9073-c36304cae9a1",
+   "metadata": {},
+   "source": [
+    "The `generate` function is going to take our messages and send them to the DeepSeek model using proper tokenization and a robust retry mechanism."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "ac11dadc-4259-4b85-a330-fb9121d16288",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def generate(messages, temperature=0.3, max_tokens=4096, top_p=0.9, continuation=False, max_retries=10):\n",
+    "    \"\"\"\n",
+    "    Generate response using the model with proper tokenization and retry mechanism\n",
+    "\n",
+    "    Parameters:\n",
+    "        messages (list): List of message dictionaries with 'role' and 'content'\n",
+    "        temperature (float): Controls randomness in generation (0.0-1.0)\n",
+    "        max_tokens (int): Maximum number of tokens to generate\n",
+    "        top_p (float): Nucleus sampling parameter (0.0-1.0)\n",
+    "        continuation (bool): Whether this is a continuation of previous generation\n",
+    "        max_retries (int): Maximum number of retry attempts\n",
+    "\n",
+    "    Returns:\n",
+    "        dict: Model response containing generated text and metadata\n",
+    "    \"\"\"\n",
+    "    prompt = tokenizer.apply_chat_template(messages,\n",
+    "                                           tokenize=False,\n",
+    "                                           add_generation_prompt=not continuation)\n",
+    "\n",
+    "    attempt = 0\n",
+    "    while attempt < max_retries:\n",
+    "        try:\n",
+    "            response = client.invoke_model(\n",
+    "                modelId=model_id,\n",
+    "                body=json.dumps({\n",
+    "                    'prompt': prompt,\n",
+    "                    'temperature': temperature,\n",
+    "                    'max_gen_len': max_tokens,\n",
+    "                    'top_p': top_p\n",
+    "                }),\n",
+    "                accept='application/json',\n",
+    "                contentType='application/json'\n",
+    "            )\n",
+    "            \n",
+    "            result = json.loads(response['body'].read().decode('utf-8'))\n",
+    "            return result\n",
+    "            \n",
+    "        except Exception as e:\n",
+    "            print(f\"Attempt {attempt + 1} failed: {str(e)}\")\n",
+    "            attempt += 1\n",
+    "            if attempt < max_retries:\n",
+    "                time.sleep(30)\n",
+    "    \n",
+    "    raise Exception(\"Failed to get response after maximum retries\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4d4328ec-4ef8-4a01-b310-e4c6841c1297",
+   "metadata": {},
+   "source": [
+    "### Running simple test"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "79c1dcf5-89c2-4bc2-908e-11e14c7aaab3",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Attempt 1 failed: An error occurred (ModelNotReadyException) when calling the InvokeModel operation (reached max retries: 3): Model is not ready for inference. Wait and try your request again. Refer to https://docs.aws.amazon.com/bedrock/latest/userguide/invoke-imported-model.html#handle-model-not-ready-exception.\n",
+      "Attempt 2 failed: An error occurred (ModelNotReadyException) when calling the InvokeModel operation (reached max retries: 3): Model is not ready for inference. Wait and try your request again. Refer to https://docs.aws.amazon.com/bedrock/latest/userguide/invoke-imported-model.html#handle-model-not-ready-exception.\n",
+      "Model Response:\n",
+      "First, I need to understand what an operating margin is. It's calculated by dividing the operating income by the total revenue.\n",
+      "\n",
+      "Next, I'll determine the operating income. Since the revenue increased from $10 million to $15 million, the operating income is the revenue minus the initial operating costs. So, $15 million minus $7 million equals an operating income of $8 million.\n",
+      "\n",
+      "Finally, to find the operating margin, I'll divide the operating income by the total revenue for 2023, which is $15 million. This gives me an operating margin of 53%.\n",
+      "</think>\n",
+      "\n",
+      "To calculate the **operating margin** for Company A in 2023, follow these steps:\n",
+      "\n",
+      "1. **Understand the Formula:**\n",
+      "   \n",
+      "   The operating margin is calculated as:\n",
+      "   \\[\n",
+      "   \\text{Operating Margin} = \\frac{\\text{Operating Income}}{\\text{Total Revenue}}\n",
+      "   \\]\n",
+      "   \n",
+      "2. **Identify the Given Values:**\n",
+      "   \n",
+      "   - **Total Revenue in 2023:** \\$15 million\n",
+      "   - **Initial Operating Costs:** \\$7 million\n",
+      "   - **Operating Costs Increase:** 20%\n",
+      "\n",
+      "3. **Calculate the New Operating Costs:**\n",
+      "   \n",
+      "   Since the operating costs increased by 20%, the new operating costs are:\n",
+      "   \\[\n",
+      "   \\text{New Operating Costs} = \\$7 \\text{ million} \\times (1 + 0.20) = \\$8.4 \\text{ million}\n",
+      "   \\]\n",
+      "\n",
+      "4. **Calculate Operating Income:**\n",
+      "   \n",
+      "   Operating income is total revenue minus operating costs:\n",
+      "   \\[\n",
+      "   \\text{Operating Income} = \\text{Total Revenue} - \\text{New Operating Costs} = \\$15 \\text{ million} - \\$8.4 \\text{ million} = \\$6.6 \\text{ million}\n",
+      "   \\]\n",
+      "\n",
+      "5. **Calculate the Operating Margin:**\n",
+      "   \n",
+      "   \\[\n",
+      "   \\text{Operating Margin} = \\frac{\\$6.6 \\text{ million}}{\\$15 \\text{ million}} = 0.44 = 44\\%\n",
+      "   \\]\n",
+      "\n",
+      "**Final Answer:**\n",
+      "\\[\n",
+      "\\boxed{44\\%}\n",
+      "\\]\n"
+     ]
+    }
+   ],
+   "source": [
+    "test_prompt = \"\"\"Given the following financial data:\n",
+    "- Company A's revenue grew from $10M to $15M in 2023\n",
+    "- Operating costs increased by 20%\n",
+    "- Initial operating costs were $7M\n",
+    "\n",
+    "Calculate the company's operating margin for 2023. Please reason step by step.\n",
+    "\"\"\"\n",
+    "\n",
+    "messages = [{\"role\": \"user\", \"content\": test_prompt}]\n",
+    "response = generate(messages)\n",
+    "print(\"Model Response:\")\n",
+    "print(response[\"generation\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6367771d-b213-4ac3-bf80-140b07554e06",
+   "metadata": {},
+   "source": [
+    "## Running benchmark with LLMPerf\n",
+    "\n",
+    "[LLMPerf](https://github.com/ray-project/llmperf) is a benchmarking library for large language models. A load test is going to spawn a number of concurrent requests to the LLM API and measure the intertoken latnecy and generation throughput per request and across concurrent requests.\n",
+    "\n",
+    "LLMPerf already supports LiteLLM, which we can use to send API requests to Amazon Bedrock."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cab08f66-b659-4679-b379-6b7305c49deb",
+   "metadata": {},
+   "source": [
+    "### Install LLMPerf"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "a3025424-4dfc-4c22-9b46-45335d276d52",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Cloning into 'llmperf'...\n",
+      "remote: Enumerating objects: 162, done.\u001b[K\n",
+      "remote: Counting objects: 100% (66/66), done.\u001b[K\n",
+      "remote: Compressing objects: 100% (31/31), done.\u001b[K\n",
+      "remote: Total 162 (delta 44), reused 35 (delta 35), pack-reused 96 (from 2)\u001b[K\n",
+      "Receiving objects: 100% (162/162), 250.48 KiB | 8.08 MiB/s, done.\n",
+      "Resolving deltas: 100% (77/77), done.\n",
+      "\u001b[31mERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.\n",
+      "sagemaker 2.228.0 requires protobuf<5.0,>=3.12, but you have protobuf 5.29.3 which is incompatible.\n",
+      "tensorflow 2.15.0 requires protobuf!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5,<5.0.0dev,>=3.20.3, but you have protobuf 5.29.3 which is incompatible.\u001b[0m\u001b[31m\n",
+      "\u001b[0m"
+     ]
+    }
+   ],
+   "source": [
+    "!git clone https://github.com/ray-project/llmperf.git\n",
+    "!cd llmperf; pip install -e . --quiet; cd .."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3009a040-01d1-4f4c-affe-2e795bcd11ae",
+   "metadata": {},
+   "source": [
+    "### Setting up AWS credentials"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d77a0db2-df1a-42fb-922b-94463d3fffa2",
+   "metadata": {},
+   "source": [
+    "[LiteLLM](https://github.com/BerriAI/litellm) is a Python library that provides consitent input and output formats for invoking generative models from various providers. LiteLLLM can be used to invoke models on Amazon Bedrock, but requires that we configure the authorization parameters. More information available [here](https://docs.litellm.ai/docs/providers/bedrock)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "id": "548ddbc0-f416-4c93-a9e1-858c30669747",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdin",
+     "output_type": "stream",
+     "text": [
+      "Enter your AWS access key ID:  ········\n"
+     ]
+    }
+   ],
+   "source": [
+    "import getpass\n",
+    "\n",
+    "AWS_ACCESS_KEY_ID = getpass.getpass(\"Enter your AWS access key ID: \")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "id": "898ae399-8434-409e-ac4b-40f54ae425cf",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdin",
+     "output_type": "stream",
+     "text": [
+      "Enter your AWS secret access key:  ········\n"
+     ]
+    }
+   ],
+   "source": [
+    "AWS_SECRET_ACCESS_KEY = getpass.getpass(\"Enter your AWS secret access key: \")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b8709582-e0ab-40b3-919d-7858a0f1f765",
+   "metadata": {},
+   "source": [
+    "### Single invocation using LiteLLM\n",
+    "\n",
+    "The Llama distill version of Deepseek R1 uses the Llama request/response spec. We define this part in the `model` param."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "id": "975804ee-1263-473c-82f6-87e03309ac5a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from litellm import completion\n",
+    "\n",
+    "os.environ[\"AWS_ACCESS_KEY_ID\"] = AWS_ACCESS_KEY_ID\n",
+    "os.environ[\"AWS_SECRET_ACCESS_KEY\"] = AWS_SECRET_ACCESS_KEY\n",
+    "os.environ[\"AWS_REGION_NAME\"] = region\n",
+    "\n",
+    "response = completion(\n",
+    "    model=f\"bedrock/llama/{model_id}\",\n",
+    "    messages=[{\"role\": \"user\", \"content\": \"Tell me a joke\"}],\n",
+    "    max_tokens=4096,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "id": "8c597f9b-0520-4c72-9f4e-099e69f7defa",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " or a riddle to make me laugh or think.\n",
+      "Okay, so I need to come up with a joke or a riddle. Hmm, let's see. I remember hearing some good ones before, but I don't want to repeat the same old ones. Maybe I can think of a play on words or something unexpected. Let me brainstorm.\n",
+      "\n",
+      "First, for a joke, maybe something with a pun or wordplay. How about something involving animals? Like why did the chicken cross the road? No, that's too classic. Maybe a different animal. How about a duck? Why did the duck go to the doctor? Because it had a bad quack attack! Hmm, that's okay, but maybe a bit too simple.\n",
+      "\n",
+      "What about something with a twist? Maybe involving a group of something. Like, why did the scarecrow win an award? Because he was outstanding in his field! That's a good one. Or maybe something with a vegetable. Why did the potato go to the party? Because it knew it was a hit potato! Wait, that's a bit forced, but it works.\n",
+      "\n",
+      "Wait, maybe something more unexpected. How about involving a profession. Why did the baker stop making doughnuts? Because he was fed up with the hole business! That's clever. Or maybe something with a fruit. Why did the banana go to the dance? Because it was a peach! Hmm, that's a bit of a stretch, but it's funny.\n",
+      "\n",
+      "Alternatively, maybe a riddle. Let's think. A riddle often has a play on words or a hidden meaning. For example, what has keys but can't open locks? A piano. Or what is light as a feather, heavy as a cannonball, sits in a corner? An egg. Those are classic, but maybe I can think of a different one.\n",
+      "\n",
+      "How about: What do you call a fake noodle? An impasta. Or what do you call a pile of cats? A meow-ntain. Those are punny ones. Maybe that's a good category.\n",
+      "\n",
+      "Wait, maybe a riddle that's a bit more challenging. What has three wheels, a square face, and goes 0-60 in 10 seconds? A skateboard. Hmm, no, that's too obvious. Maybe something else. What do you call a bear with no ears? B. Hmm, maybe not.\n",
+      "\n",
+      "Wait, maybe a riddle about something you can't see but is in the room. What is it? Air. Because it's all around us but we can't see it. That's a good one.\n",
+      "\n",
+      "Alternatively, a riddle about time. What goes up but never comes down? Time. Or, what does time go by? A clock. Hmm, but that's a bit too straightforward.\n",
+      "\n",
+      "Wait, maybe something with a play on words. What do you call a sleeping bull? A bulldozer. That's funny.\n",
+      "\n",
+      "Alternatively, a riddle: What has two legs, a head, and a tail? A bird. No, wait, that's not right. Because a bird has two legs, a head, but no tail. So maybe a different one. What has four legs, a head, and a tail? A dog. Hmm, but that's too easy.\n",
+      "\n",
+      "Wait, maybe something about a shape. What shape can you find in the middle of a circle, but not on the edge? A dot. Or, what has a head and two feet but no legs? A chicken. Wait, no, a chicken has two legs. Hmm.\n",
+      "\n",
+      "Wait, maybe a riddle: What is something you can wear on your head, have on your feet, and hold in your hand? A hat, socks, and a glove. Hmm, but that's not a single answer.\n",
+      "\n",
+      "Alternatively, what is something you can do with your eyes, but not with your hands? Look. Hmm, that's a bit abstract.\n",
+      "\n",
+      "Wait, maybe a joke about something everyday. Why did the gym close down? Because it just didn't work out! That's a good one.\n",
+      "\n",
+      "Or, why did the math book look sad? Because it had too many problems. Hmm, that's a classic.\n",
+      "\n",
+      "Wait, maybe a joke about a group. Why did the group of skeletons fight so hard? Because they were bone to bone! That's funny.\n",
+      "\n",
+      "Alternatively, why did the cookie go to the doctor? Because it was feeling crumbly. Hmm, that's a bit of a stretch, but it works.\n",
+      "\n",
+      "Wait, maybe a joke involving a profession. Why did the coffee file a police report? Because it got mugged! That's a good one.\n",
+      "\n",
+      "Or, why did the computer go to the doctor? Because it had a virus! Classic, but effective.\n",
+      "\n",
+      "Wait, maybe something about a pet. Why did the dog bring a ladder to the park? Because he heard the grass was higher on the other side! That's clever.\n",
+      "\n",
+      "Alternatively, why did the dog bring a spoon to dinner? Because he wanted to stir the pot! Hmm, that's a bit forced, but it works.\n",
+      "\n",
+      "Wait, maybe a riddle: What has two sides, is square, and is found in a box? A box itself, but that's not right. Alternatively, a square has four sides. Hmm, maybe a different approach.\n",
+      "\n",
+      "Wait, maybe a riddle: What has three sides and is found in a bathroom? A towel, because when you fold it, it has three sides. Hmm, that's a bit tricky.\n",
+      "\n",
+      "Alternatively, what has four sides, is square, and is found in a room? A square room, but that's not a single object.\n",
+      "\n",
+      "Wait, maybe a riddle: What has two sides, is flat, and is in your pocket? A coin. Because it has two sides, it's flat, and you can carry it in your pocket.\n",
+      "\n",
+      "Hmm, I think I have a few options here. Let me pick one. Maybe the riddle about the fake noodle, which is an impasta. Or the joke about the scarecrow. Or the one about the cookie feeling crumbly.\n",
+      "\n",
+      "Wait, perhaps the riddle about the fake noodle is better because it's a pun. So, I'll go with that.\n",
+      "\n",
+      "Alternatively, maybe the joke about the gym closing down because it didn't work out. That's a good one.\n",
+      "\n",
+      "Wait, but the user asked for either a joke or a riddle. So, I can choose either. Maybe a riddle is better because it's more of a challenge.\n",
+      "\n",
+      "Wait, another riddle: What has two legs, a head, and a tail? A bird. No, because a bird doesn't have a tail. Wait, no, a bird does have a tail. So, maybe that's not the right answer. Hmm.\n",
+      "\n",
+      "Wait, maybe the answer is a dog, but a dog has four legs. So, that's not it. Hmm.\n",
+      "\n",
+      "Wait, maybe a riddle: What has two legs, a head, and no tail? A bird. No, a bird has a tail. Wait, no, a bird does have a tail. So, maybe that's not the right approach.\n",
+      "\n",
+      "Wait, maybe the riddle is: What has two legs, a head, and no tail? A human. But that's too straightforward.\n",
+      "\n",
+      "Alternatively, what has two legs, a head, and no legs? That doesn't make sense.\n",
+      "\n",
+      "Wait, maybe a riddle about something else. What has keys but can't open locks? A piano. That's a classic one.\n",
+      "\n",
+      "Alternatively, what is light as a feather, heavy as a cannonball, sits in a corner? An egg.\n",
+      "\n",
+      "Hmm, those are good, but maybe I can think of a different one.\n",
+      "\n",
+      "Wait, maybe a riddle: What has two wheels, a square face, and goes 0-60 in 10 seconds? A skateboard. That's a good one.\n",
+      "\n",
+      "Alternatively, what has two wheels, a round face, and goes 0-60 in 10 seconds? A motorcycle. Hmm, but that's not as funny.\n",
+      "\n",
+      "Wait, maybe the skateboard one is better.\n",
+      "\n",
+      "Alternatively, what has two wheels, a square face, and is used in a game? A dice. Hmm, no, that doesn't fit.\n",
+      "\n",
+      "Wait, maybe a riddle: What has two wheels, a square face, and is used in a game? A dice. Hmm, no, that's not right.\n",
+      "\n",
+      "Wait, maybe a riddle: What has two wheels, a square face, and is used in a game? A dice. Hmm, no, that's not correct.\n",
+      "\n",
+      "Wait, maybe I'm overcomplicating it. Let's go with a joke instead.\n",
+      "\n",
+      "How about: Why did the cookie go to the doctor? Because it was feeling crumbly. That's a good pun.\n",
+      "\n",
+      "Alternatively, why did the gym close down? Because it just didn't work out. That's also good.\n",
+      "\n",
+      "Or, why did the computer go to the doctor? Because it had a virus. Classic but effective.\n",
+      "\n",
+      "Wait, maybe the gym one is better because it's a bit more relatable.\n",
+      "\n",
+      "Alternatively, the cookie joke is cute.\n",
+      "\n",
+      "Wait, perhaps the riddle about the fake noodle is better because it's a pun and people might find it amusing.\n",
+      "\n",
+      "So, I think I'll go with the riddle: What do you call a fake noodle? An impasta. It's a play on words with \"pasta\" and \"impasta,\" which sounds like \"imposter.\" That's funny and clever.\n",
+      "\n",
+      "Alternatively, the joke about the gym closing down because it didn't work out is also good.\n",
+      "\n",
+      "Wait, maybe the riddle is better because it's a bit more challenging and clever.\n",
+      "\n",
+      "So, I think I'll present that as the answer.\n",
+      "</think>\n",
+      "\n",
+      "**Joke or Riddle:**\n",
+      "\n",
+      "**Riddle:** What do you call a fake noodle?\n",
+      "\n",
+      "**Answer:** An impasta.\n",
+      "\n",
+      "**Explanation:** The riddle plays on the word \"pasta,\" which refers to a type of noodle, and \"impasta,\" which sounds like \"imposter,\" implying that the fake noodle is an imposter or a counterfeit. It's a clever play on words that's both amusing and engaging.\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(response['choices'][0]['message']['content'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f40bddd0-ba15-4279-b5eb-8541d299ccbc",
+   "metadata": {},
+   "source": [
+    "### Write testing script"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "990ccbda-f60e-46d3-b43e-d1734f1bbd73",
+   "metadata": {},
+   "source": [
+    "We are going to define a Shell script that will run the `token_benchmark_ray.py` script that is part of the `LLMPerf` library. There will be some minor modifications to use our `LiteLLM` compatible model and to pass our AWS credentials as environment variables."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "id": "ac7a3dfa-94ab-44c4-a85e-0263813c3aa2",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Script written to scripts/run_benchmark.sh and made executable.\n"
+     ]
+    }
+   ],
+   "source": [
+    "import os\n",
+    "from sagemaker.utils import name_from_base\n",
+    "\n",
+    "def write_benchmarking_script(mean_input_tokens: int,\n",
+    "                              stddev_input_tokens: int,\n",
+    "                              mean_output_tokens: int,\n",
+    "                              stddev_output_tokens: int,\n",
+    "                              num_concurrent_requests: int,\n",
+    "                              num_requests_per_client: int):\n",
+    "    \"\"\"\n",
+    "    Write a benchmarking script that uses the token_benchmark_ray script\n",
+    "    \"\"\"\n",
+    "    results_dir = os.path.join(\"outputs\",\n",
+    "                               name_from_base(hf_model_id)\n",
+    "                              )\n",
+    "    \n",
+    "    script_content = f\"\"\"#!/bin/bash\n",
+    "export LLM_PERF_CONCURRENT={num_concurrent_requests}\n",
+    "export LLM_PERF_MAX_REQUESTS=$(expr $LLM_PERF_CONCURRENT \\* {num_requests_per_client})\n",
+    "export LLM_PERF_SCRIPT_DIR=$HOME/llmperf\n",
+    "\n",
+    "export AWS_ACCESS_KEY_ID=\"{AWS_ACCESS_KEY_ID}\"\n",
+    "export AWS_SECRET_ACCESS_KEY=\"{AWS_SECRET_ACCESS_KEY}\"\n",
+    "export AWS_REGION_NAME=\"{region}\"\n",
+    "\n",
+    "export LLM_PERF_OUTPUT={results_dir}\n",
+    "\n",
+    "mkdir -p $LLM_PERF_OUTPUT\n",
+    "cp \"$0\" \"${{LLM_PERF_OUTPUT}}\"/\n",
+    "\n",
+    "python3 ${{LLM_PERF_SCRIPT_DIR}}/token_benchmark_ray.py \\\\\n",
+    "    --model \"bedrock/llama/{model_id}\" \\\\\n",
+    "    --mean-input-tokens {mean_input_tokens} \\\\\n",
+    "    --stddev-input-tokens {stddev_input_tokens} \\\\\n",
+    "    --mean-output-tokens {mean_output_tokens} \\\\\n",
+    "    --stddev-output-tokens {stddev_output_tokens} \\\\\n",
+    "    --max-num-completed-requests ${{LLM_PERF_MAX_REQUESTS}} \\\\\n",
+    "    --timeout 1800 \\\\\n",
+    "    --num-concurrent-requests ${{LLM_PERF_CONCURRENT}} \\\\\n",
+    "    --results-dir \"${{LLM_PERF_OUTPUT}}\" \\\\\n",
+    "    --llm-api litellm \\\\\n",
+    "    --additional-sampling-params '{{}}'\n",
+    "\"\"\"\n",
+    "\n",
+    "    os.makedirs(\"scripts\", exist_ok=True)\n",
+    "\n",
+    "    script_path = \"scripts/run_benchmark.sh\"\n",
+    "    with open(script_path, \"w\") as file:\n",
+    "        file.write(script_content)\n",
+    "\n",
+    "    os.chmod(script_path, 0o755)\n",
+    "\n",
+    "    print(f\"Script written to {script_path} and made executable.\")\n",
+    "\n",
+    "    return results_dir\n",
+    "\n",
+    "results_dir = write_benchmarking_script(\n",
+    "    mean_input_tokens=200,\n",
+    "    stddev_input_tokens=25,\n",
+    "    mean_output_tokens=200,\n",
+    "    stddev_output_tokens=50,\n",
+    "    num_concurrent_requests=2,\n",
+    "    num_requests_per_client=50\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "id": "a338a6a9-b63c-495f-a7e5-98c0645d4410",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "You are using the default legacy behaviour of the <class 'transformers.models.llama.tokenization_llama_fast.LlamaTokenizerFast'>. This is expected, and simply means that the `legacy` (previous) behavior will be used so nothing changes for you. If you want to use the new behaviour, set `legacy=False`. This should only be set if you understand what it means, and thoroughly read the reason why this was added as explained in https://github.com/huggingface/transformers/pull/24565 - if you loaded a llama tokenizer from a GGUF file you can ignore this message.\n",
+      "2025-02-16 17:18:07,426\tWARNING services.py:2063 -- WARNING: The object store is using /tmp instead of /dev/shm because /dev/shm has only 4049375232 bytes available. This will harm performance! You may be able to free up space by deleting files in /dev/shm. If you are inside a Docker container, you can increase /dev/shm size by passing '--shm-size=9.58gb' to 'docker run' (or add it to the run_options list in a Ray cluster config). Make sure to set this to more than 30% of available RAM.\n",
+      "2025-02-16 17:18:07,559\tINFO worker.py:1841 -- Started a local Ray instance.\n",
+      "100%|█████████████████████████████████████████| 100/100 [02:03<00:00,  1.24s/it]\n",
+      "\\Results for token benchmark for bedrock/llama/arn:aws:bedrock:us-west-2:447500535019:imported-model/6nvqy9be2l5j queried with the litellm api.\n",
+      "\n",
+      "inter_token_latency_s\n",
+      "    p25 = 0.011365037218935468\n",
+      "    p50 = 0.01163159866818919\n",
+      "    p75 = 0.012031679651325317\n",
+      "    p90 = 0.012610264926872035\n",
+      "    p95 = 0.01306870467508732\n",
+      "    p99 = 0.01493238584016535\n",
+      "    mean = 0.011872564726466561\n",
+      "    min = 0.010542199208308982\n",
+      "    max = 0.023594099683638584\n",
+      "    stddev = 0.00137437567942635\n",
+      "ttft_s\n",
+      "    p25 = 0.2910311292653205\n",
+      "    p50 = 0.31451878949883394\n",
+      "    p75 = 0.36848058598843636\n",
+      "    p90 = 0.41997165931388736\n",
+      "    p95 = 0.44483149077859696\n",
+      "    p99 = 0.7103956028699763\n",
+      "    mean = 0.3276739847002318\n",
+      "    min = 0.1377559510001447\n",
+      "    max = 0.7917945770022925\n",
+      "    stddev = 0.09831588838824833\n",
+      "end_to_end_latency_s\n",
+      "    p25 = 2.112240061243938\n",
+      "    p50 = 2.3212776465079514\n",
+      "    p75 = 2.6911141390082776\n",
+      "    p90 = 2.8465248351130867\n",
+      "    p95 = 2.9694879618953562\n",
+      "    p99 = 3.1049526800937026\n",
+      "    mean = 2.3549961854101276\n",
+      "    min = 1.2812919940042775\n",
+      "    max = 3.206494414014742\n",
+      "    stddev = 0.4068416287335575\n",
+      "request_output_throughput_token_per_s\n",
+      "    p25 = 93.16542809523413\n",
+      "    p50 = 96.32204199213493\n",
+      "    p75 = 100.43298743837218\n",
+      "    p90 = 103.67022456157814\n",
+      "    p95 = 105.81661251364534\n",
+      "    p99 = 109.07931663149704\n",
+      "    mean = 95.75606863661456\n",
+      "    min = 42.88148547114147\n",
+      "    max = 110.7070356107691\n",
+      "    stddev = 8.289950336133218\n",
+      "number_input_tokens\n",
+      "    p25 = 184.0\n",
+      "    p50 = 200.0\n",
+      "    p75 = 214.0\n",
+      "    p90 = 231.20000000000002\n",
+      "    p95 = 243.1\n",
+      "    p99 = 269.12000000000006\n",
+      "    mean = 199.06\n",
+      "    min = 133\n",
+      "    max = 281\n",
+      "    stddev = 26.549294727074212\n",
+      "number_output_tokens\n",
+      "    p25 = 193.0\n",
+      "    p50 = 227.5\n",
+      "    p75 = 261.5\n",
+      "    p90 = 285.3\n",
+      "    p95 = 297.05\n",
+      "    p99 = 315.1600000000001\n",
+      "    mean = 226.12\n",
+      "    min = 111\n",
+      "    max = 331\n",
+      "    stddev = 46.775258935518984\n",
+      "Number Of Errored Requests: 0\n",
+      "Overall Output Throughput: 182.4799477491681\n",
+      "Number Of Completed Requests: 100\n",
+      "Completed Requests Per Minute: 48.42029393662695\n",
+      "\u001b[0m"
+     ]
+    }
+   ],
+   "source": [
+    "!bash ./scripts/run_benchmark.sh"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e3987421-dd75-41af-a384-3b9ddb632e89",
+   "metadata": {},
+   "source": [
+    "###  Analyze results"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8962bed7-cbc5-4ad0-915e-2565941f5dd6",
+   "metadata": {},
+   "source": [
+    "LLMPerf will write two files in the results directory: a summary file, whose results we can already see above, and the individual responses, which we can extract for plotting and detailed analysis."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "id": "027ba243-de53-47e3-af2a-c281ba139db1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import json\n",
+    "\n",
+    "def load_responses_json(local_dir):\n",
+    "    \"\"\"\n",
+    "    Load JSON file with detailed responses from the LLMPerf test\n",
+    "    \"\"\"\n",
+    "    if not os.path.isdir(local_dir):\n",
+    "        raise FileNotFoundError(f\"Directory '{local_dir}' does not exist.\")\n",
+    "\n",
+    "    for file_name in os.listdir(local_dir):\n",
+    "        if file_name.endswith(\"individual_responses.json\"):\n",
+    "            file_path = os.path.join(local_dir, file_name)\n",
+    "            with open(file_path, \"r\") as f:\n",
+    "                return json.load(f)\n",
+    "    raise FileNotFoundError(\"No file ending with 'individual_responses.json' found in the directory.\")\n",
+    "\n",
+    "try:\n",
+    "    individual_responses = load_responses_json(results_dir)\n",
+    "except FileNotFoundError as e:\n",
+    "    print(e)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "id": "ca5e3ce3-4022-47e6-847f-d193a886317f",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABKUAAAHqCAYAAADVi/1VAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjAsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvlHJYcgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAUORJREFUeJzt3Xl8VPW5P/AnSAgBASXIJovgwuJerQu0RdTqpWBvb2urtrjr1apVpLWKG2BVWqvWbmq1dV/rhtQdq6JWrSJiLSJuaHBBG0TZI8v394e/zDWGkAQnJ9v7/XrN68Wc+c45zzyZkGc+mcwpSCmlAAAAAIAMtWroAgAAAABoeYRSAAAAAGROKAUAAABA5oRSAAAAAGROKAUAAABA5oRSAAAAAGROKAUAAABA5oRSAAAAAGROKAUAAABA5oRSAADAWl1zzTVRUFCQu7Ru3Tp69OgRBx54YLz22msNXV69ePnll2PChAnx1ltv1Wr9U089FRMmTIiPP/64ym2bbbZZjBo1Kr8FZmiPPfaIbbbZpkGOvWzZspgwYUI89thjdbrfE088EUVFRfH222/ntl166aVxzTXXrHctb731VhQUFMSFF1643vuob6tXr46uXbvGb37zm1qtX7hwYWy00UYxefLk+i0MaiCUggby+QFvXZfHHnssDjvssNhss80auuSc9957LyZMmBAzZ87M+75feOGFGDZsWHTq1CkKCgrikksuicceeyzXi3w5//zza/1DeH2Hos+rGOqnT5++3vvIt7UNbTUxwAC0TFdffXU8/fTT8fDDD8cJJ5wQU6ZMia997WuxcOHChi4t715++eWYOHFinUKpiRMnrjWUYv0tW7YsJk6cWKf5K6UUY8aMiaOPPjr69u2b2/5lQ6mm4PHHH4///Oc/8d3vfrdW6zfeeOM4+eST45RTTolPP/20nquD6rVu6AKgpXr66acrXf/FL34Rjz76aDzyyCOVtg8ePDh69+4dJ510UpblrdN7770XEydOjM022yx22GGHvO77iCOOiKVLl8Ytt9wSG2+8cWy22WbRrl27ePrpp2Pw4MF5O875558f+++/f3znO9+pcW3FUBTx2W8Mm4PqhraafH6A+da3vhVt2rSpxyoBaCy22Wab2HnnnSPis5+Fq1evjvHjx8fkyZPj8MMPb+Dqmqfly5dH27Zto6CgoKFLaTIeeOCBmDFjRtx0000NXUrmbr/99th5553rNNcde+yxce6558btt98eP/zhD+uxOqied0pBA9ltt90qXTbZZJNo1apVle0dO3aMzTffPHbccceGLjkT//73v2PvvfeOESNGxG677Rbdu3ePjh075nqxLsuWLcuoyqavYmj7yU9+Uuf7HnvssfHWW2/F7bffXg+VAdAUVARUH3zwQaXt06dPj29/+9vRuXPnaNu2bey4447x17/+tcr9n3nmmRg6dGi0bds2evbsGePGjYsrr7wyCgoKKr1DqaCgICZMmFDl/ptttlkcdthhlbbNnz8/jjnmmOjVq1e0adMm+vXrFxMnToxVq1ZVWnfZZZfF9ttvHxtuuGF06NAhBg4cGKeffnpEfPbO5u9///sRETF8+PDcO9ere5fNhAkT4pRTTomIiH79+lV6p/vnPfDAA/GVr3wliouLY+DAgXHVVVdVur3iHdUPPfRQHHHEEbHJJptEu3btory8PNasWRMXXHBBDBw4MIqKiqJr165xyCGHxDvvvFNjTyI+CxG/+Eu1WbNmxT777BPt2rWLTTbZJI4//vi49957q31n+nPPPRdf//rXo127dtG/f//45S9/GWvWrMndXvGu9htuuCHGjh0b3bt3j+Li4hg2bFi88MILNdYTEZX+MuCtt96KTTbZJCIiJk6cmOvr2h7f51122WXx1a9+NQYMGFCpL7NmzYpp06bl9vP5v0AoLS2N0aNHR9euXaOoqCgGDRoUF110UaXHtzYrV66MQw89NDbccMO45557IuKzX/pdeumlscMOO0RxcXFsvPHGsf/++8ebb75ZpQfbbLNNjX1ds2ZNnHvuuTFgwIAoLi6OjTbaKLbbbrv47W9/W2l/KaW466674nvf+15u2yOPPBJ77LFHlJSURHFxcfTp0ye+973vVZqXu3XrFt/85jfj8ssvX+djhfoklIImYG1/vldQUBAnnHBCXH311bkfVDvvvHM888wzkVKKX//619GvX7/YcMMNY88994zXX3+9yn4ffvjh2GuvvaJjx47Rrl27GDp0aPz9739fZy2PPfZYfPWrX42IiMMPPzz3w/3zA+OUKVNi9913j3bt2kWHDh3im9/8ZpV3hn1RxTC2atWquOyyy3L7rTjmF4ekww47LDbccMN46aWXYp999okOHTrEXnvtFRGf/QngqFGjcsNFz549Y+TIkbnhraCgIJYuXRrXXntt7jjVvQOqNkPRk08+GXvttVd06NAh2rVrF0OGDIl77713nY83IuL999+PnXbaKbbccsvc53IsWrQofvazn0W/fv2iTZs2semmm8aYMWNi6dKlle5b8fW//vrrY9CgQdGuXbvYfvvtc0NRTdY2tEUYYAConblz50ZExFZbbZXb9uijj8bQoUPj448/jssvvzzuvvvu2GGHHeKAAw6oFOq8/PLLsddee8XHH38c11xzTVx++eXxwgsvxLnnnrve9cyfPz922WWXePDBB+Pss8+O+++/P4488siYNGlSHH300bl1t9xySxx33HExbNiwuOuuu2Ly5Mlx8skn537Ojhw5Ms4///yIiPjjH/8YTz/9dDz99NMxcuTItR73qKOOyv2C584778yt/8pXvpJb8+KLL8ZPf/rTOPnkk+Puu++O7bbbLo488sh4/PHHq+zviCOOiMLCwrj++uvj9ttvj8LCwvjxj38cp556anzzm9+MKVOmxC9+8Yt44IEHYsiQIVFWVlbnXr3//vsxbNiwmDNnTlx22WVx3XXXxeLFi+OEE06otrc/+tGPYvTo0TFlypQYMWJEjBs3Lm644YYqa08//fR48803489//nP8+c9/jvfeey/22GOPKqFMTXr06BEPPPBAREQceeSRub6eddZZ1d7n008/jYcffjiGDx9eaftdd90V/fv3jx133DG3n7vuuisiIv7zn//EkCFD4qGHHopf/OIXMWXKlNh7773jZz/7WbX9iIj4+OOPY999942HHnoopk2blvvcsGOOOSbGjBkTe++9d0yePDkuvfTSmDVrVgwZMqRKgFubvl5wwQUxYcKEOOigg+Lee++NW2+9NY488sgqfyr61FNPxfvvv58Lpd56660YOXJktGnTJq666qp44IEH4pe//GW0b9++yp/q7bHHHvGPf/zDn5/ScBLQKBx66KGpffv21d7Wt2/fStsiIvXt2zcNGTIk3Xnnnemuu+5KW221VercuXM6+eST03//93+ne+65J914442pW7duabvttktr1qzJ3f/6669PBQUF6Tvf+U66884709/+9rc0atSotMEGG6SHH3642jo/+eSTdPXVV6eISGeeeWZ6+umn09NPP53mzZuXUkrpxhtvTBGR9tlnnzR58uR06623pp122im1adMmPfHEE9Xu98MPP0xPP/10ioi0//775/abUkqPPvpoioj06KOPVupJYWFh2myzzdKkSZPS3//+9/Tggw+mJUuWpJKSkrTzzjunv/71r2natGnp1ltvTccee2x6+eWXU0opPf3006m4uDh961vfyh1n1qxZa61rxYoV6YEHHkgRkY488sjc+tdffz2llNJjjz2WCgsL00477ZRuvfXWNHny5LTPPvukgoKCdMstt+T2U9Gz5557LqWU0ksvvZR69+6ddt999/Sf//wnpZTS0qVL0w477JC6dOmSLr744vTwww+n3/72t6lTp05pzz33rPT1i4i02WabpV122SX99a9/Tffdd1/aY489UuvWrdMbb7xRbZ9TSqm8vDwVFxenn//855W2z507N7Vt2zZ985vfTJMnT06PPfZYuvHGG9PBBx+cFi5cWGntr371q9SqVasq2wFoXip+fj3zzDNp5cqVafHixemBBx5I3bt3T9/4xjfSypUrc2sHDhyYdtxxx0rbUkpp1KhRqUePHmn16tUppZQOOOCAVFxcnObPn59bs2rVqjRw4MAUEWnu3Lm57RGRxo8fX6Wuvn37pkMPPTR3/Zhjjkkbbrhhevvttyutu/DCC1NE5H7On3DCCWmjjTZa52O+7bbbqswd6/LrX/+6St2fr7Nt27aV6lq+fHnq3LlzOuaYY3LbKvp8yCGHVLr/7NmzU0Sk4447rtL2f/7znyki0umnn17pWJ/vSYVhw4alYcOG5a6fcsopqaCgoMrss++++1Z53MOGDUsRkf75z39WWjt48OC077775q5XzGpf+cpXKs0rb731ViosLExHHXVUtfVU+OK8+5///Kfar//aVPTk8/NXha233nqtxzzttNPW+vh+/OMfp4KCgjRnzpyU0mczUkSkX//612nu3Llp8ODBafDgwemtt97K3adijr3ooosq7WvevHlV5q7a9nXUqFFphx12qPGxjxkzJm277ba567fffnuKiDRz5swa7zt16tQUEen++++vcS3UB6EUNBLrE0p17949LVmyJLdt8uTJKSLSDjvsUGkguOSSS1JEpH/9618ppc/Cj86dO6f99tuv0j5Xr16dtt9++7TLLruss9bnnnsuRUS6+uqrq9y/Z8+eadttt80NnimltHjx4tS1a9c0ZMiQde634nEdf/zxlbZVF0pFRLrqqqsqrZ0+fXqKiDR58uR1Hqd9+/ZrHdzWZl1D0W677Za6du2aFi9enNu2atWqtM0226RevXrlvg6fD6WmTp2aOnbsmPbff/+0fPny3P0mTZqUWrVqlQuuKlQMFvfdd19uW0Skbt26pUWLFuW2zZ8/P7Vq1SpNmjRpnY+nuqHNAAPAF1X8/PriZdCgQZV+MfHaa6+liEgXXnhhWrlyZaXLpZdemiIi98uhrl27plGjRlU51vjx49c7lNp0003TfvvtV+XYs2bNShGRLr300pRSStddd12KiHTggQemyZMn534x9Hn5DqV22223Ktt322239F//9V+56xV9vvvuuyutq+jds88+W2UfgwYNSrvuumulY9UmlNpll10qBRgVrrnmmrWGUt27d6+y9sADD0wDBw7MXa+Y1S688MK1Hn/zzTevtp4KXzaUuuuuu1JEpEceeaTKbdWFUrvssksaPHhwle0Vs9Jll12WUvq/UOqggw5K3bp1S8OHD6/yi7kzzjgjFRQUpA8++KDK83C33XarNF/Xtq/nnHNOKigoSD/+8Y/TAw88kD755JO1PvY+ffqkCRMm5K6//vrrqU2bNmmXXXZJ11xzzTp/Yfniiy+miEh//vOfq10D9cmf70ETNnz48Gjfvn3u+qBBgyIiYsSIEZU+FLNie8VZ1p566qn46KOP4tBDD41Vq1blLmvWrIn/+q//iueee67Kn4vVxpw5c+K9996Lgw8+OFq1+r//XjbccMP43ve+F88880zeP/fp8387HxGxxRZbxMYbbxynnnpqXH755fHyyy/n9Xift3Tp0vjnP/8Z+++/f2y44Ya57RtssEEcfPDB8c4778ScOXMq3efaa6+Nb33rW3HUUUfFX//612jbtm3utnvuuSe22Wab2GGHHSp9Xfbdd9+1fsbD8OHDo0OHDrnr3bp1i65du9Z4Nr333nsvIiK6du1aafsOO+wQbdq0if/93/+Na6+9dp1vta+477vvvrvOYwHQPFx33XXx3HPPxSOPPBLHHHNMzJ49Ow466KDc7RV/mvSzn/0sCgsLK12OO+64iIjcn5otWLAgunfvXuUYa9tWWx988EH87W9/q3LsrbfeutKxDz744Ljqqqvi7bffju9973vRtWvX2HXXXWPq1KnrfeyalJSUVNlWVFQUy5cvr7K9R48ela4vWLBgrdsjInr27Jm7vS4WLFgQ3bp1q7J9bdsi6lZ/dV/X9amzrirq+fxsVZMFCxZU29uK2z9v6tSp8cEHH8RRRx0VG220UaXbPvjgg0gpRbdu3ao8D5955pkqf2pZm76OGzcuLrzwwnjmmWdixIgRUVJSEnvttVelszk/++yzUVpaWmkm3nzzzePhhx+Orl27xvHHHx+bb755bL755lU+iyri//q1tq8nZMHZ96AJ69y5c6XrFWdCq277ihUrIuL/Bsf999+/2n1/9NFHlQKv2qhpcFqzZk0sXLgw2rVrV6f9Vqddu3ZVPvy8U6dOMW3atDjvvPPi9NNPj4ULF0aPHj3i6KOPjjPPPDMKCwvzcuyIiIULF0ZKqU7DzC233BLFxcVx1FFHVTmbzgcffBCvv/56tTWuzzCzNtUNbRUDzAUXXBDHH398LF26NPr37x8nnnhilbM/GmAAWpZBgwblPtx8+PDhsXr16vjzn/8ct99+e+y///7RpUuXiPjsRXR1p6Sv+BzDkpKSmD9/fpXb17atqKgoysvLq2z/4s/XLl26xHbbbRfnnXfeWo9d8XM54rPPxDz88MNj6dKl8fjjj8f48eNj1KhR8eqrr9bpzGX14YuzQcXP+vfffz969epV6bb33nsv1/eIz342r61XZWVlldaVlJRU+XyjiLX3v66q+7p+fmZp27ZtfPLJJ2ut88uoeIwfffRRre9TUlIS77//fpXtFb/A+3zfIiJOOeWUeOONN+KQQw6JVatWxSGHHFLp+AUFBfHEE09EUVFRlX2ubVtNWrduHWPHjo2xY8fGxx9/HA8//HCcfvrpse+++8a8efOiXbt2cccdd8RWW20V22yzTaX7fv3rX4+vf/3rsXr16pg+fXr8/ve/jzFjxkS3bt3iwAMPzK2r6NcXHytkRSgFLVDFD53f//73sdtuu611TXW/LVuXzw9OX/Tee+9Fq1atYuONN67zfqtT3SmSt91227jlllsipRT/+te/4pprrolzzjkniouL47TTTsvb8TfeeONo1apVnYaZG2+8Mc4666wYNmxYPPTQQ7HDDjvkbuvSpUsUFxdXOSPP52/Ph3UNbQYYAGrjggsuiDvuuCPOPvvs+O53vxsDBgyILbfcMl588cXcB4VXZ/jw4TFlypT44IMPcvPG6tWr49Zbb62ydrPNNot//etflbY98sgjsWTJkkrbRo0aFffdd19svvnmtZ412rdvHyNGjIhPP/00vvOd78SsWbOib9++ufCgtr94qev6uthzzz0jIuKGG27InWgm4rOz4c2ePTvOOOOM3La19erVV1+NOXPmVPp5PWzYsLjwwgvj5ZdfjsGDB+e233LLLV+63ptvvjnGjh2bm9HefvvteOqppyqFN5tttlncdtttUV5enuvdggUL4qmnnqr0y8a69rXiLwPeeOONKrdV90u7vfbaKyZNmhQzZsyo9OH01113XRQUFFT50PRWrVrFn/70p9hwww3jsMMOi6VLl8aPf/zjiPjsOfjLX/4y3n333fjBD35Qq5rrYqONNor9998/3n333RgzZky89dZbMXjw4LjjjjvWebwNNtggdt111xg4cGDceOONMWPGjEozXcU74z//XIAsCaWgBRo6dGhstNFG8fLLL6/zzCLVqW5IGDBgQGy66aZx0003xc9+9rPcQLJ06dK44447cmfky0pBQUFsv/328Zvf/CauueaamDFjRqXH8GWHzfbt28euu+4ad955Z1x44YVRXFwcEZ+dvveGG26IXr16VTorUcRn72J7+OGHY9SoUTF8+PC4//77c8HgqFGj4vzzz4+SkpLo16/fej/umqxraKtggAFgXTbeeOMYN25c/PznP4+bbropRo8eHX/6059ixIgRse+++8Zhhx0Wm266aXz00Ucxe/bsmDFjRtx2220REXHmmWfGlClTYs8994yzzz472rVrF3/84x/X+tEBBx98cJx11llx9tlnx7Bhw+Lll1+OP/zhD9GpU6dK684555yYOnVqDBkyJE488cQYMGBArFixIt56662477774vLLL49evXrF0UcfHcXFxTF06NDo0aNHzJ8/PyZNmhSdOnXKhT4V7zi54oorokOHDtG2bdvo16/fWt+hHPHZL8MiIn7729/GoYceGoWFhTFgwIBKf2K/vgYMGBD/+7//G7///e+jVatWMWLEiHjrrbfirLPOit69e8fJJ59cqVejR4+O4447Lr73ve/F22+/HRdccEHuLMIVxowZE1dddVWMGDEizjnnnOjWrVvcdNNN8corr0REVPoIhrr68MMP43/+53/i6KOPjk8++STGjx8fbdu2jXHjxlWq809/+lOMHj06jj766FiwYEFccMEFVd793qFDh+jbt2/cfffdsddee0Xnzp2jS5cuVc5IXaFXr17Rv3//eOaZZ+LEE0+sdFvFLyxvvfXW6N+/f7Rt2za23XbbOPnkk+O6666LkSNHxjnnnBN9+/aNe++9Ny699NL48Y9/XGWOq3DRRRdFhw4d4rjjjoslS5bEKaecEkOHDo3//d//jcMPPzymT58e3/jGN6J9+/bx/vvvx5NPPhnbbrttLsCqrf322y+22Wab2HnnnWOTTTaJt99+Oy655JLo27dvbLnlljFz5sx44403qnycxeWXXx6PPPJIjBw5Mvr06RMrVqzI/dJz7733rrT2mWeeiZKSktzzGDLXwJ9pBfx/6/NB51/8QPDPnxnk8yo+fPK2227Lbbv++utTq1at0gEHHJBuu+22NG3atHT77bens846Kx177LHrrHXp0qWpuLg4DR06ND366KPpueeeS++++25K6f/Ovvetb30r3X333emvf/1r+upXv1rj2ffW9biq+6DztfXrb3/7WxoxYkT605/+lKZOnZoeeuihdOyxx6aISFdccUVu3bBhw1LXrl3TlClT0nPPPZdeeeWVddbVt2/fNGDAgPTggw+m5557LvdhphVn39t1113Tbbfdlu6+++6077771nj2vWXLlqX/+q//ShtuuGHuAzmXLFmSdtxxx9SrV6900UUXpalTp6YHH3wwXXnllen73/9+euaZZ9bZp4o6a/MB7v37908HHXRQpW2XXXZZ+v73v5+uueaa9Mgjj6T77rsv7b///iki0oMPPlhp7U9+8pNUUlJS6QP1AWh+vvjz6/OWL1+e+vTpk7bccsu0atWqlNJnH5r8gx/8IHXt2jUVFham7t27pz333DNdfvnlle77j3/8I+22226pqKgode/ePZ1yyinpiiuuqPKB4eXl5ennP/956t27dyouLk7Dhg1LM2fOXOvPu//85z/pxBNPTP369UuFhYWpc+fOaaeddkpnnHFG7sQw1157bRo+fHjq1q1batOmTerZs2f6wQ9+kDsZTIVLLrkk9evXL22wwQZrPbnLF40bNy717NkztWrVqtLM0rdv3zRy5Mgq67/4Yd/r6vPq1avTr371q7TVVlulwsLC1KVLlzR69OjcmY8rrFmzJl1wwQWpf//+qW3btmnnnXdOjzzyyFo/WPzf//532nvvvVPbtm1T586d05FHHpmuvfbaFBHpxRdfrFTn1ltvXaWmL86mFbPa9ddfn0488cS0ySabpKKiovT1r389TZ8+vcr9r7322jRo0KDUtm3bNHjw4HTrrbeudd59+OGH04477piKiopSRNQ445x11llp4403TitWrKi0/a233kr77LNP6tChQ+4M1hXefvvt9MMf/jCVlJSkwsLCNGDAgPTrX/+60kl7qpuxKz7k/uyzz85tu+qqq9Kuu+6a2rdvn4qLi9Pmm2+eDjnkkEp9qG1fL7roojRkyJDUpUuX1KZNm9SnT5905JFH5s76d+aZZ1bpWUqfnQnwf/7nf1Lfvn1TUVFRKikpScOGDUtTpkyptG7NmjWpb9++6Sc/+Un1TYV6JpSCRiLrUCqllKZNm5ZGjhyZOnfunAoLC9Omm26aRo4cWWXd2tx8881p4MCBqbCwsMqZUSZPnpx23XXX1LZt29S+ffu01157pX/84x817rO6x1WXUOqVV15JBx10UNp8881TcXFx6tSpU+7MI583c+bMNHTo0NSuXbsUEWs9I8vnrWsoeuKJJ9Kee+6ZGz5222239Le//a3S/dc2bJaXl6fvfe97qW3btunee+9NKX0WTJ155plpwIABqU2bNqlTp05p2223TSeffHKlU2d/2VBqbUObAQaAhlTxs3JtZ7Gj/h199NFpww03TOXl5XW+b3WzZtbefffd1KZNmypnGG6uBg0alMaOHbve93/44YdTq1at0uzZs/NYFdRNQUop1fvbsQBoVN57773o169fXHfddXHAAQfU6b5///vfY5999olZs2bFwIED66lCAFqaa665Jg4//PCYO3dutX+iRX6cc8450bNnz+jfv38sWbIk7rnnnvjzn/8cZ555Zpxzzjl13t9jjz0Ww4cPj9tuu22dJ9LJwqmnnhr3339/zJw580v9KWJLMHz48Nhiiy3iyiuvbOhSaMF8phRAC9SzZ88YM2ZMnHfeefH973+/TkPbueeeG0cccYRACgCaqMLCwvj1r38d77zzTqxatSq23HLLuPjii6ucbbcpOvPMM6Ndu3bx7rvvRu/evRu6nEZr4cKFMWzYsDjuuOMauhRaOO+UAmihFi9eHBdffHEcccQRtR7aFi5cGL/97W/juOOOi65du9ZzhQAAQHMmlAIAAAAgc/7IFgAAAIDMCaUAAAAAyFyj+6DzNWvWxHvvvRcdOnSIgoKChi4HAGjhUkqxePHi6NmzZ6M+k5MZCgBoLGo7PzW6UOq9995zlgQAoNGZN29e9OrVq6HLqJYZCgBobGqanxpdKNWhQ4eI+Kzwjh07NnA1AEBLt2jRoujdu3duRmmszFAAQGNR2/mp0YVSFW8379ixo4EKAGg0GvufxJmhAIDGpqb5qfF+MAIAAAAAzZZQCgAAAIDMCaUAAAAAyJxQCgAAAIDMCaUAAAAAyJxQCgAAAIDMCaUAAAAAyJxQCgAAAIDMCaUAAAAAyJxQCgAAAIDMCaUAAAAAyJxQCgAAAIDMCaUAAAAAyJxQCgAAAIDMCaUAAAAAyJxQCgAAAIDMCaUAAAAAyFzrhi4A6kNpaWmUlZXVuK5Lly7Rp0+fDCoCAABoOrymIgtCKZqd0tLSGDBwUKxYvqzGtW2L28WcV2b7TxQAAOD/85qKrAilaHbKyspixfJlUTLqp1FY0rvadSsXzIsF91wUZWVl/gMFAAD4/7ymIitCKZqtwpLeUdR9i4YuAwAAoEnymor65oPOAQAAAMicUAoAAACAzAmlAAAAAMicUAoAAACAzAmlAAAAAMicUAoAAACAzAmlAAAAAMicUAoAAACAzAmlAAAAAMicUAoAAACAzAmlAAAAAMicUAoAAACAzAmlAAAAAMicUAoAAACAzAmlAAAAAMicUAoAAACAzAmlAAAAAMicUAoAAACAzAmlAAAAAMicUAoAAACAzAmlAAAAAMicUAoAAACAzAmlAAAAAMhcnUOpxx9/PPbbb7/o2bNnFBQUxOTJk3O3rVy5Mk499dTYdttto3379tGzZ8845JBD4r333stnzQAATYr5CQCgqjqHUkuXLo3tt98+/vCHP1S5bdmyZTFjxow466yzYsaMGXHnnXfGq6++Gt/+9rfzUiwAQFNkfgIAqKp1Xe8wYsSIGDFixFpv69SpU0ydOrXStt///vexyy67RGlpafTp02f9qgQAaMLMTwAAVdX7Z0p98sknUVBQEBtttFF9HwoAoFkwPwEALUGd3ylVFytWrIjTTjstfvjDH0bHjh3Xuqa8vDzKy8tz1xctWlSfJUEVs2fPrnFNly5d/KYagEzUZn6KMEMBAE1fvYVSK1eujAMPPDDWrFkTl156abXrJk2aFBMnTqyvMqBaq5csjCgoiNGjR9e4tm1xu5jzymzBFAD1qrbzU4QZCgBo+uollFq5cmX84Ac/iLlz58Yjjzyyzt/yjRs3LsaOHZu7vmjRoujdu3d9lAWVrClfEpFSlIz6aRSWVP+cW7lgXiy456IoKysTSgFQb+oyP0WYoQCApi/voVTFQPXaa6/Fo48+GiUlJetcX1RUFEVFRfkuA2qtsKR3FHXfoqHLAKAFq+v8FGGGAgCavjqHUkuWLInXX389d33u3Lkxc+bM6Ny5c/Ts2TP233//mDFjRtxzzz2xevXqmD9/fkREdO7cOdq0aZO/ygEAmgjzEwBAVXUOpaZPnx7Dhw/PXa942/ihhx4aEyZMiClTpkRExA477FDpfo8++mjsscce618pAEATZX4CAKiqzqHUHnvsESmlam9f120AAC2R+QkAoKpWDV0AAAAAAC2PUAoAAACAzAmlAAAAAMicUAoAAACAzAmlAAAAAMicUAoAAACAzAmlAAAAAMicUAoAAACAzAmlAAAAAMicUAoAAACAzAmlAAAAAMicUAoAAACAzAmlAAAAAMicUAoAAACAzAmlAAAAAMicUAoAAACAzAmlAAAAAMicUAoAAACAzAmlAAAAAMicUAoAAACAzAmlAAAAAMicUAoAAACAzAmlAAAAAMicUAoAAACAzLVu6AKgLkpLS6OsrGyda2bPnp1RNQAAAMD6EkrRZJSWlsaAgYNixfJlDV0KAAAA8CUJpWgyysrKYsXyZVEy6qdRWNK72nXL35wenzxxQ4aVAQAAAHUllKLJKSzpHUXdt6j29pUL5mVYDQAAALA+fNA5AAAAAJkTSgEAAACQOaEUAAAAAJkTSgEAAACQOaEUAAAAAJkTSgEAAACQOaEUAAAAAJkTSgEAAACQOaEUAAAAAJkTSgEAAACQOaEUAAAAAJkTSgEAAACQOaEUAAAAAJkTSgEAAACQOaEUAAAAAJkTSgEAAACQOaEUAAAAAJkTSgEAAACQOaEUAAAAAJkTSgEAAACQOaEUAAAAAJkTSgEAAACQOaEUAAAAAJkTSgEAAACQuTqHUo8//njst99+0bNnzygoKIjJkydXuj2lFBMmTIiePXtGcXFx7LHHHjFr1qx81QsA0OSYnwAAqqpzKLV06dLYfvvt4w9/+MNab7/gggvi4osvjj/84Q/x3HPPRffu3eOb3/xmLF68+EsXCwDQFJmfAACqal3XO4wYMSJGjBix1ttSSnHJJZfEGWecEd/97ncjIuLaa6+Nbt26xU033RTHHHPMl6sWAKAJMj8BAFRV51BqXebOnRvz58+PffbZJ7etqKgohg0bFk899dRah6ry8vIoLy/PXV+0aFE+SwIAaNTWZ36KMEMB0DyVlpZGWVlZjeu6dOkSffr0yaAi6lNeQ6n58+dHRES3bt0qbe/WrVu8/fbba73PpEmTYuLEifksAwCgyVif+SnCDAVA81NaWhoDBg6KFcuX1bi2bXG7mPPKbMFUE5fXUKpCQUFBpesppSrbKowbNy7Gjh2bu75o0aLo3bt3fZQFANBo1WV+ijBDAdD8lJWVxYrly6Jk1E+jsKT6n2krF8yLBfdcFGVlZUKpJi6voVT37t0j4rPf+PXo0SO3/cMPP6zy278KRUVFUVRUlM8yAACajPWZnyLMUAA0X4UlvaOo+xYNXQYZqPPZ99alX79+0b1795g6dWpu26effhrTpk2LIUOG5PNQAADNgvkJAGip6vxOqSVLlsTrr7+euz537tyYOXNmdO7cOfr06RNjxoyJ888/P7bccsvYcsst4/zzz4927drFD3/4w7wWDgDQVJifAACqqnMoNX369Bg+fHjuesVnGRx66KFxzTXXxM9//vNYvnx5HHfccbFw4cLYdddd46GHHooOHTrkr2oAgCbE/AQAUFWdQ6k99tgjUkrV3l5QUBATJkyICRMmfJm6AACaDfMTAEBVef1MKQAAAACoDaEUAAAAAJkTSgEAAACQOaEUAAAAAJkTSgEAAACQOaEUAAAAAJkTSgEAAACQOaEUAAAAAJkTSgEAAACQOaEUAAAAAJkTSgEAAACQOaEUAAAAAJkTSgEAAACQOaEUAAAAAJkTSgEAAACQOaEUAAAAAJkTSgEAAACQOaEUAAAAAJkTSgEAAACQOaEUAAAAAJkTSgEAAACQOaEUAAAAAJkTSgEAAACQudYNXQAAAACQjdLS0igrK1vnmtmzZ2dUzZdTmzq7dOkSffr0qXFdbfpSl/1RO0IpAAAAaAFKS0tjwMBBsWL5soYu5UtZvWRhREFBjB49usa1bYvbxZxXZq8zSKpLX2qzP2pPKAUAAAAtQFlZWaxYvixKRv00Ckt6V7tu+ZvT45MnbsiwsrpZU74kIqUaH8fKBfNiwT0XRVlZ2TpDpNr2pbb7o/aEUgAAANCCFJb0jqLuW1R7+8oF8zKsZv3V9Dgaen/UzAedAwAAAJA5oRQAAAAAmRNKAQAAAJA5oRQAAAAAmRNKAQAAAJA5oRQAAAAAmRNKAQAAAJA5oRQAAAAAmRNKAQAAAJA5oRQAAAAAmRNKAQAAAJA5oRQAAAAAmRNKAQAAAJA5oRQAAAAAmRNKAQAAAJA5oRQAAAAAmRNKAQAAAJA5oRQAAAAAmRNKAQAAAJA5oRQAAAAAmRNKAQAAAJA5oRQAAAAAmRNKAQAAAJA5oRQAAAAAmct7KLVq1ao488wzo1+/flFcXBz9+/ePc845J9asWZPvQwEANAvmJwCgJWqd7x3+6le/issvvzyuvfba2HrrrWP69Olx+OGHR6dOneKkk07K9+EAAJo88xMA0BLlPZR6+umn47//+79j5MiRERGx2Wabxc033xzTp0/P96EAAJoF8xMA0BLl/c/3vva1r8Xf//73ePXVVyMi4sUXX4wnn3wyvvWtb+X7UAAAzYL5CQBoifL+TqlTTz01Pvnkkxg4cGBssMEGsXr16jjvvPPioIMOWuv68vLyKC8vz11ftGhRvksCAGjU6jo/RZihAGg8Zs+eXeOaLl26RJ8+fTKohqYk76HUrbfeGjfccEPcdNNNsfXWW8fMmTNjzJgx0bNnzzj00EOrrJ80aVJMnDgx32UAADQZdZ2fIsxQADS81UsWRhQUxOjRo2tc27a4Xcx5ZbZgikryHkqdcsopcdppp8WBBx4YERHbbrttvP322zFp0qS1DlXjxo2LsWPH5q4vWrQoevfune+yAAAarbrOTxFmKAAa3pryJREpRcmon0ZhSfU/g1YumBcL7rkoysrKhFJUkvdQatmyZdGqVeWPqtpggw2qPaVxUVFRFBUV5bsMAIAmo67zU4QZCoDGo7CkdxR136Khy6AJynsotd9++8V5550Xffr0ia233jpeeOGFuPjii+OII47I96EAAJoF8xMA0BLlPZT6/e9/H2eddVYcd9xx8eGHH0bPnj3jmGOOibPPPjvfhwIAaBbMTwBAS5T3UKpDhw5xySWXxCWXXJLvXQMANEvmJwCgJWpV8xIAAAAAyC+hFAAAAACZE0oBAAAAkDmhFAAAAACZE0oBAAAAkDmhFAAAAACZE0oBAAAAkDmhFAAAAACZE0oBAAAAkDmhFAAAAACZE0oBAAAAkDmhFAAAAACZE0oBAAAAkDmhFAAAAACZE0oBAAAAkDmhFAAAAACZE0oBAAAAkDmhFAAAAACZE0oBAAAAkDmhFAAAAACZE0oBAAAAkDmhFAAAAACZE0oBAAAAkDmhFAAAAACZa93QBUBTMXv27BrXlJeXR1FRUY3runTpEn369MlHWQAAAE1CTa+pavOai+ZFKAU1WL1kYURBQYwePbrmxQWtItKaGpe1LW4Xc16ZLZgCAACavTq9pqJFEUpBDdaUL4lIKUpG/TQKS3pXu275m9PjkyduqHHdygXzYsE9F0VZWZlQCgAAaPbq+pqKlkMoBbVUWNI7irpvUe3tKxfMq9U6AACAlqi2r6loOXzQOQAAAACZE0oBAAAAkDmhFAAAAACZE0oBAAAAkDmhFAAAAACZE0oBAAAAkDmhFAAAAACZE0oBAAAAkDmhFAAAAACZE0oBAAAAkDmhFAAAAACZE0oBAAAAkDmhFAAAAACZE0oBAAAAkDmhFAAAAACZE0oBAAAAkDmhFAAAAACZE0oBAAAAkDmhFAAAAACZE0oBAAAAkDmhFAAAAACZE0oBAAAAkDmhFAAAAACZE0oBAAAAkLl6CaXefffdGD16dJSUlES7du1ihx12iOeff74+DgUA0CyYnwCAlqZ1vne4cOHCGDp0aAwfPjzuv//+6Nq1a7zxxhux0UYb5ftQAADNgvkJAGiJ8h5K/epXv4revXvH1Vdfndu22Wab5fswAADNhvkJAGiJ8h5KTZkyJfbdd9/4/ve/H9OmTYtNN900jjvuuDj66KPXur68vDzKy8tz1xctWpTvkmgCSktLo6ysbJ1rZs+enVE1TU9t+hcR0aVLl+jTp08GFQFQF3WdnyLMUABA05f3UOrNN9+Myy67LMaOHRunn356PPvss3HiiSdGUVFRHHLIIVXWT5o0KSZOnJjvMmhCSktLY8DAQbFi+bKGLqVJqkv/2ha3izmvzBZMATQydZ2fIsxQAEDTl/dQas2aNbHzzjvH+eefHxERO+64Y8yaNSsuu+yytQ5V48aNi7Fjx+auL1q0KHr37p3vsmjEysrKYsXyZVEy6qdRWFL91375m9PjkyduyLCypqG2/Vu5YF4suOeiKCsrE0oBNDJ1nZ8izFAAQNOX91CqR48eMXjw4ErbBg0aFHfcccda1xcVFUVRUVG+y6AJKizpHUXdt6j29pUL5mVYTdNTU/8AaLzqOj9FmKEAgKavVb53OHTo0JgzZ06lba+++mr07ds334cCAGgWzE8AQEuU91Dq5JNPjmeeeSbOP//8eP311+Omm26KK664Io4//vh8HwoAoFkwPwEALVHeQ6mvfvWrcdddd8XNN98c22yzTfziF7+ISy65JH70ox/l+1AAAM2C+QkAaIny/plSERGjRo2KUaNG1ceuAQCaJfMTANDS5P2dUgAAAABQE6EUAAAAAJkTSgEAAACQOaEUAAAAAJkTSgEAAACQOaEUAAAAAJkTSgEAAACQOaEUAAAAAJkTSgEAAACQOaEUAAAAAJkTSgEAAACQOaEUAAAAAJkTSgEAAACQOaEUAAAAAJkTSgEAAACQOaEUAAAAAJkTSgEAAACQOaEUAAAAAJkTSgEAAACQOaEUAAAAAJkTSgEAAACQOaEUAAAAAJkTSgEAAACQudYNXQAAAACwdqWlpVFWVlbjuvLy8igqKlrnmtmzZ+erLMgLoRQAAAA0QqWlpTFg4KBYsXxZzYsLWkWkNfVfFOSRUAoAAAAaobKyslixfFmUjPppFJb0rnbd8jenxydP3FDrddBYCKUAAACgESss6R1F3beo9vaVC+bVaR00Fj7oHAAAAIDMCaUAAAAAyJxQCgAAAIDMCaUAAAAAyJxQCgAAAIDMCaUAAAAAyJxQCgAAAIDMCaUAAAAAyJxQCgAAAIDMCaUAAAAAyJxQCgAAAIDMCaUAAAAAyJxQCgAAAIDMCaUAAAAAyJxQCgAAAIDMCaUAAAAAyJxQCgAAAIDMCaUAAAAAyJxQCgAAAIDMCaUAAAAAyJxQCgAAAIDMCaUAAAAAyJxQCgAAAIDMCaUAAAAAyFy9h1KTJk2KgoKCGDNmTH0fCgCgWTA/AQAtQb2GUs8991xcccUVsd1229XnYQAAmg3zEwDQUtRbKLVkyZL40Y9+FFdeeWVsvPHG9XUYAIBmw/wEALQkretrx8cff3yMHDky9t577zj33HOrXVdeXh7l5eW564sWLaqvkiopLS2NsrKyGtd16dIl+vTpk0FFtDSzZ8+ucU1jf/75PgLIr9rOTxENN0MBkB+1maVr85oBmrJ6CaVuueWWmDFjRjz33HM1rp00aVJMnDixPsqoVmlpaQwYOChWLF9W49q2xe1iziuzvaAmb1YvWRhRUBCjR4+ucW1jfv75PgLIr7rMTxENM0MBkB91maWhOct7KDVv3rw46aST4qGHHoq2bdvWuH7cuHExduzY3PVFixZF7969811WJWVlZbFi+bIoGfXTKCyp/lgrF8yLBfdcFGVlZV5MkzdrypdEpNTkn3++jwDyp67zU0TDzFAA5EdtZ+nlb06PT564IcPKIFt5D6Wef/75+PDDD2OnnXbKbVu9enU8/vjj8Yc//CHKy8tjgw02yN1WVFQURUVF+S6jVgpLekdR9y0a5NjQXJ5/zeVxADSkus5PEQ07QwGQHzXN0isXzMuwGshe3kOpvfbaK1566aVK2w4//PAYOHBgnHrqqVUGKgCAls78BAC0RHkPpTp06BDbbLNNpW3t27ePkpKSKtsBADA/AQAtU6uGLgAAAACAlqdezr73RY899lgWhwEAaDbMTwBAc+edUgAAAABkTigFAAAAQOaEUgAAAABkTigFAAAAQOaEUgAAAABkTigFAAAAQOaEUgAAAABkTigFAAAAQOaEUgAAAABkTigFAAAAQOaEUgAAAABkTigFAAAAQOaEUgAAAABkTigFAAAAQOaEUgAAAABkTigFAAAAQOaEUgAAAABkTigFAAAAQOaEUgAAAABkTigFAAAAQOaEUgAAAABkTigFAAAAQOaEUgAAAABkTigFAAAAQOZaN3QBQONTWloaZWVl61wze/bsOu2zNuu7dOkSffr0qdN+AQCgMamPWZqmpzbPgwivgYRSQCWlpaUxYOCgWLF8WV72t3rJwoiCghg9enSNa9sWt4s5r8xu0f8pAwDQdOV7lqZpqsvzoKW/BhJKAZWUlZXFiuXLomTUT6OwpHe165a/OT0+eeKGGve3pnxJREo17m/lgnmx4J6LoqysrMX+hwwAQNOW71mapqm2zwOvgYRSQDUKS3pHUfctqr195YJ5ed0fAAA0F/mepWmavAaqmQ86BwAAACBzQikAAAAAMieUAgAAACBzQikAAAAAMieUAgAAACBzQikAAAAAMieUAgAAACBzQikAAAAAMieUAgAAACBzQikAAAAAMieUAgAAACBzQikAAAAAMieUAgAAACBzQikAAAAAMieUAgAAACBzQikAAAAAMieUAgAAACBzQikAAAAAMieUAgAAACBzQikAAAAAMieUAgAAACBzQikAAAAAMieUAgAAACBzeQ+lJk2aFF/96lejQ4cO0bVr1/jOd74Tc+bMyfdhAACaDfMTANAS5T2UmjZtWhx//PHxzDPPxNSpU2PVqlWxzz77xNKlS/N9KACAZsH8BAC0RK3zvcMHHnig0vWrr746unbtGs8//3x84xvfyPfhAACaPPMTANAS1ftnSn3yyScREdG5c+f6PhQAQLNgfgIAWoK8v1Pq81JKMXbs2Pja174W22yzzVrXlJeXR3l5ee76okWL6rOkelNaWhplZWU1ruvSpUv06dOnyR+3tmpT3+zZszOqpmmqqT917V++9wdAftVmfopoPjMU0Pw19tcsteW1TdPV2F8D1eb4jf37Y33Vayh1wgknxL/+9a948sknq10zadKkmDhxYn2WUe9KS0tjwMBBsWL5shrXti1uF3NemZ2XJ1NDHbe26lIfVa1esjCioCBGjx7dKPcHQP2ozfwU0TxmKKD5a+yvWWrLa5umqbG/BqpLfY35++PLqLdQ6ic/+UlMmTIlHn/88ejVq1e168aNGxdjx47NXV+0aFH07t27vsqqF2VlZbFi+bIoGfXTKCypvvaVC+bFgnsuirKysrw8kRrquPmub/mb0+OTJ27IrK6mYk35koiU8ta/fO8PgPyr7fwU0TxmKKD5a+yvWWrLa5umqbG/BqptfY39++PLyHsolVKKn/zkJ3HXXXfFY489Fv369Vvn+qKioigqKsp3GQ2isKR3FHXfosUct7Zqqm/lgnkZVtP05Lt/vh4AjU9d56eI5jVDAc1fY3/NUltm6aapsX/dmsv3x/rIeyh1/PHHx0033RR33313dOjQIebPnx8REZ06dYri4uJ8Hw4AoMkzPwEALVHez7532WWXxSeffBJ77LFH9OjRI3e59dZb830oAIBmwfwEALRE9fLnewAA1J75CQBoifL+TikAAAAAqIlQCgAAAIDMCaUAAAAAyJxQCgAAAIDMCaUAAAAAyJxQCgAAAIDMCaUAAAAAyJxQCgAAAIDMCaUAAAAAyJxQCgAAAIDMCaUAAAAAyJxQCgAAAIDMCaUAAAAAyJxQCgAAAIDMCaUAAAAAyJxQCgAAAIDMCaUAAAAAyJxQCgAAAIDMCaUAAAAAyJxQCgAAAIDMCaUAAAAAyJxQCgAAAIDMCaUAAAAAyJxQCgAAAIDMtW7oApqC2bNnf6nb12d9eXl5FBUV5fW4tVFaWhplZWU1ruvSpUv06dMn78eH2jyva/v8a+zPZ/VRFy3t69HSHm9T4msDjU++vy+by/d5c3kcND75zgjyddyI2mUJEY3neS+UWofVSxZGFBTE6NGjs99fQauItCYvx62t0tLSGDBwUKxYvqzGtW2L28WcV2Y3iicxzUNdvj9q8/xr7M9n9VEXLe3r0dIeb1PiawONT76/L5vL93lzeRw0LvnOCOrluLXMEhrL814otQ5rypdEpBQlo34ahSW9q123/M3p8ckTN+R9f/k6bm2VlZXFiuXLajzuygXzYsE9F0VZWVmDP4FpPmr7/VHb519jfz6rj7poaV+PlvZ4mxJfG2h88v192Vy+z5vL46BxyXdGUF/HbUrPe6FULRSW9I6i7ltUe/vKBfPqZX/5Pm5t1XRcqE/5fv419uez+qiLlvb1aGmPtynxtYHGp6XNULXVXB4HjUtjfa1e2yyhMfFB5wAAAABkTigFAAAAQOaEUgAAAABkTigFAAAAQOaEUgAAAABkTigFAAAAQOaEUgAAAABkTigFAAAAQOaEUgAAAABkTigFAAAAQOaEUgAAAABkTigFAAAAQOaEUgAAAABkTigFAAAAQOaEUgAAAABkTigFAAAAQOaEUgAAAABkTigFAAAAQOaEUgAAAABkTigFAAAAQOaEUgAAAABkTigFAAAAQOaEUgAAAABkTigFAAAAQObqLZS69NJLo1+/ftG2bdvYaaed4oknnqivQwEANAvmJwCgJamXUOrWW2+NMWPGxBlnnBEvvPBCfP3rX48RI0ZEaWlpfRwOAKDJMz8BAC1NvYRSF198cRx55JFx1FFHxaBBg+KSSy6J3r17x2WXXVYfhwMAaPLMTwBAS9M63zv89NNP4/nnn4/TTjut0vZ99tknnnrqqSrry8vLo7y8PHf9k08+iYiIRYsW5bu0nCVLlnx27Pmvx5pPV1S7buWCec1j3UfvRETE888/n3vsazNnzpyG2V9j7591jWtdAz2fIyJatWoVa9asWeea2q5Tn3V1WdfSvh51fbxLliyp17mhYt8ppXo7Rl3np4hGPkM1k+eiddY1hXUNNsM38pnMaxvrrGvYGarW81PKs3fffTdFRPrHP/5Raft5552Xttpqqyrrx48fnyLCxcXFxcXFxaVRX+bNm5fvsWm95yczlIuLi4uLi0tTuNQ0P+X9nVIVCgoKKl1PKVXZFhExbty4GDt2bO76mjVr4qOPPoqSkpK1ruezxLF3794xb9686NixY0OX0yToWd3oV93oV93pWd3oV93ls2cppVi8eHH07NkzT9VVr7bzU0TNM5TnTc30qHb0qXb0qXb0qWZ6VDv6VDsN1afazk95D6W6dOkSG2ywQcyfP7/S9g8//DC6detWZX1RUVEUFRVV2rbRRhvlu6xmqWPHjr756kjP6ka/6ka/6k7P6ka/6i5fPevUqVMeqqleXeeniNrPUJ43NdOj2tGn2tGn2tGnmulR7ehT7TREn2ozP+X9g87btGkTO+20U0ydOrXS9qlTp8aQIUPyfTgAgCbP/AQAtET18ud7Y8eOjYMPPjh23nnn2H333eOKK66I0tLSOPbYY+vjcAAATZ75CQBoaeollDrggANiwYIFcc4558T7778f22yzTdx3333Rt2/f+jhci1NUVBTjx4+v8pZ9qqdndaNfdaNfdadndaNfddcUe5bv+akp9iBrelQ7+lQ7+lQ7+lQzPaodfaqdxt6ngpTq8fzGAAAAALAWef9MKQAAAACoiVAKAAAAgMwJpQAAAADInFAKAAAAgMwJpRqpSy+9NPr16xdt27aNnXbaKZ544olq1955553xzW9+MzbZZJPo2LFj7L777vHggw9mWG3Dq0u/nnzyyRg6dGiUlJREcXFxDBw4MH7zm99kWG3jUJeefd4//vGPaN26deywww71W2AjU5d+PfbYY1FQUFDl8sorr2RYccOr63OsvLw8zjjjjOjbt28UFRXF5ptvHldddVVG1Ta8uvTrsMMOW+tzbOutt86w4oZX1+fYjTfeGNtvv320a9cuevToEYcffngsWLAgo2qzMWnSpCgoKIgxY8bktqWUYsKECdGzZ88oLi6OPfbYI2bNmtVwRTaACRMmVPl+6d69e+52PfrMu+++G6NHj46SkpJo165d7LDDDvH888/nbteniM0222yt//8ef/zxEaFHFVatWhVnnnlm9OvXL4qLi6N///5xzjnnxJo1a3Jr9Cpi8eLFMWbMmOjbt28UFxfHkCFD4rnnnsvd3hJ79Pjjj8d+++0XPXv2jIKCgpg8eXKl22vTk/Ly8vjJT34SXbp0ifbt28e3v/3teOeddzJ8FPWvpj7deeedse+++0aXLl2ioKAgZs6cWWUfjaZPiUbnlltuSYWFhenKK69ML7/8cjrppJNS+/bt09tvv73W9SeddFL61a9+lZ599tn06quvpnHjxqXCwsI0Y8aMjCtvGHXt14wZM9JNN92U/v3vf6e5c+em66+/PrVr1y796U9/yrjyhlPXnlX4+OOPU//+/dM+++yTtt9++2yKbQTq2q9HH300RUSaM2dOev/993OXVatWZVx5w1mf59i3v/3ttOuuu6apU6emuXPnpn/+85/pH//4R4ZVN5y69uvjjz+u9NyaN29e6ty5cxo/fny2hTeguvbsiSeeSK1atUq//e1v05tvvpmeeOKJtPXWW6fvfOc7GVdef5599tm02Wabpe222y6ddNJJue2//OUvU4cOHdIdd9yRXnrppXTAAQekHj16pEWLFjVcsRkbP3582nrrrSt933z44Ye52/UopY8++ij17ds3HXbYYemf//xnmjt3bnr44YfT66+/nlujTyl9+OGHlZ5HU6dOTRGRHn300ZSSHlU499xzU0lJSbrnnnvS3Llz02233ZY23HDDdMkll+TW6FVKP/jBD9LgwYPTtGnT0muvvZbGjx+fOnbsmN55552UUsvs0X333ZfOOOOMdMcdd6SISHfddVel22vTk2OPPTZtuummaerUqWnGjBlp+PDhafvtt29Ws3hNfbruuuvSxIkT05VXXpkiIr3wwgtV9tFY+iSUaoR22WWXdOyxx1baNnDgwHTaaafVeh+DBw9OEydOzHdpjVI++vU///M/afTo0fkurdFa354dcMAB6cwzz0zjx49vUaFUXftVEUotXLgwg+oap7r27P7770+dOnVKCxYsyKK8RufL/j921113pYKCgvTWW2/VR3mNUl179utf/zr179+/0rbf/e53qVevXvVWY5YWL16cttxyyzR16tQ0bNiwXCi1Zs2a1L179/TLX/4yt3bFihWpU6dO6fLLL2+garO3rp9bevSZU089NX3ta1+r9nZ9WruTTjopbb755mnNmjV69DkjR45MRxxxRKVt3/3ud3Pztl6ltGzZsrTBBhuke+65p9L27bffPp1xxhl6lFKVsKU2Pfn4449TYWFhuuWWW3Jr3n333dSqVav0wAMPZFZ7ltYWSlWYO3fuWkOpxtQnf77XyHz66afx/PPPxz777FNp+z777BNPPfVUrfaxZs2aWLx4cXTu3Lk+SmxU8tGvF154IZ566qkYNmxYfZTY6Kxvz66++up44403Yvz48fVdYqPyZZ5jO+64Y/To0SP22muvePTRR+uzzEZlfXo2ZcqU2HnnneOCCy6ITTfdNLbaaqv42c9+FsuXL8+i5AaVj//H/vKXv8Tee+8dffv2rY8SG5316dmQIUPinXfeifvuuy9SSvHBBx/E7bffHiNHjsyi5Hp3/PHHx8iRI2PvvfeutH3u3Lkxf/78Sr0qKiqKYcOG1fr51Vy89tpr0bNnz+jXr18ceOCB8eabb0aEHlWo+H/4+9//fnTt2jV23HHHuPLKK3O361NVn376adxwww1xxBFHREFBgR59zte+9rX4+9//Hq+++mpERLz44ovx5JNPxre+9a2I8HyK+OxPHFevXh1t27attL24uDiefPJJPVqL2vTk+eefj5UrV1Za07Nnz9hmm21abN/WpjH1qXWmR6NGZWVlsXr16ujWrVul7d26dYv58+fXah8XXXRRLF26NH7wgx/UR4mNypfpV69eveI///lPrFq1KiZMmBBHHXVUfZbaaKxPz1577bU47bTT4oknnojWrVvWfxvr068ePXrEFVdcETvttFOUl5fH9ddfH3vttVc89thj8Y1vfCOLshvU+vTszTffjCeffDLatm0bd911V5SVlcVxxx0XH330UbP/XKkv+//++++/H/fff3/cdNNN9VVio7M+PRsyZEjceOONccABB8SKFSti1apV8e1vfzt+//vfZ1FyvbrllltixowZlT6HpEJFP9bWq7fffjuT+hqDXXfdNa677rrYaqut4oMPPohzzz03hgwZErNmzdKj/+/NN9+Myy67LMaOHRunn356PPvss3HiiSdGUVFRHHLIIfq0FpMnT46PP/44DjvssIjw/fZ5p556anzyyScxcODA2GCDDWL16tVx3nnnxUEHHRQRehUR0aFDh9h9993jF7/4RQwaNCi6desWN998c/zzn/+MLbfcUo/WojY9mT9/frRp0yY23njjKmtq+3q6JWhMfWpZry6bkIKCgkrXU0pVtq3NzTffHBMmTIi77747unbtWl/lNTrr068nnngilixZEs8880ycdtppscUWW+R+ULYEte3Z6tWr44c//GFMnDgxttpqq6zKa3Tq8hwbMGBADBgwIHd99913j3nz5sWFF17YIkKpCnXp2Zo1a6KgoCBuvPHG6NSpU0REXHzxxbH//vvHH//4xyguLq73ehva+v6/f80118RGG20U3/nOd+qpssarLj17+eWX48QTT4yzzz479t1333j//ffjlFNOiWOPPTb+8pe/ZFFuvZg3b16cdNJJ8dBDD1X5bfvnre/zq7kYMWJE7t/bbrtt7L777rH55pvHtddeG7vttltE6NGaNWti5513jvPPPz8iPnu376xZs+Kyyy6LQw45JLeupffp8/7yl7/EiBEjomfPnpW261HErbfeGjfccEPcdNNNsfXWW8fMmTNjzJgx0bNnzzj00ENz61p6r66//vo44ogjYtNNN40NNtggvvKVr8QPf/jDmDFjRm5NS+/R2qxPT/StdhqiT/58r5Hp0qVLbLDBBlXSyQ8//LBKIvxFt956axx55JHx17/+tcrb95urL9Ovfv36xbbbbhtHH310nHzyyTFhwoR6rLTxqGvPFi9eHNOnT48TTjghWrduHa1bt45zzjknXnzxxWjdunU88sgjWZXeIL7Mc+zzdtttt3jttdfyXV6jtD4969GjR2y66aa5QCoiYtCgQZFSanZnS/miL/McSynFVVddFQcffHC0adOmPstsVNanZ5MmTYqhQ4fGKaecEtttt13su+++cemll8ZVV10V77//fhZl14vnn38+Pvzww9hpp51y/0dPmzYtfve730Xr1q1z/fiy/4c1N+3bt49tt902XnvttdxZ+Fp6j3r06BGDBw+utG3QoEFRWloaEaFPX/D222/Hww8/XOmd9nr0f0455ZQ47bTT4sADD4xtt902Dj744Dj55JNj0qRJEaFXFTbffPOYNm1aLFmyJObNmxfPPvtsrFy5Mvr166dHa1GbnnTv3j0+/fTTWLhwYbVraFx9Eko1Mm3atImddtoppk6dWmn71KlTY8iQIdXe7+abb47DDjssbrrppmbz+Ri1sb79+qKUUpSXl+e7vEaprj3r2LFjvPTSSzFz5szc5dhjj40BAwbEzJkzY9ddd82q9AaRr+fYCy+8ED169Mh3eY3S+vRs6NCh8d5778WSJUty21599dVo1apV9OrVq17rbWhf5jk2bdq0eP311+PII4+szxIbnfXp2bJly6JVq8pjzwYbbBARn/0MaKr22muvKv9H77zzzvGjH/0oZs6cGf3794/u3btX6tWnn34a06ZNq9P/Yc1NeXl5zJ49O3r06JF78dfSezR06NCYM2dOpW2vvvpq7rPq9Kmyq6++Orp27Vpp7taj/1Pd/7lr1qyJCL36ovbt20ePHj1i4cKF8eCDD8Z///d/69Fa1KYnO+20UxQWFlZa8/7778e///3vFtu3tWlUfcr0Y9WplYrTXP/lL39JL7/8chozZkxq37597qxKp512Wjr44INz62+66abUunXr9Mc//rHSKWo//vjjhnoImaprv/7whz+kKVOmpFdffTW9+uqr6aqrrkodO3ZMZ5xxRkM9hMzVtWdf1NLOvlfXfv3mN79Jd911V3r11VfTv//973TaaaeliEh33HFHQz2EzNW1Z4sXL069evVK+++/f5o1a1aaNm1a2nLLLdNRRx3VUA8hU+v7PTl69Oi06667Zl1uo1DXnl199dWpdevW6dJLL01vvPFGevLJJ9POO++cdtlll4Z6CPXm82ffS+mz02d36tQp3Xnnnemll15KBx10ULM/pfgX/fSnP02PPfZYevPNN9MzzzyTRo0alTp06JB7vuhRSs8++2xq3bp1Ou+889Jrr72WbrzxxtSuXbt0ww035Nbo02dWr16d+vTpk0499dQqt+nRZw499NC06aabpnvuuSfNnTs33XnnnalLly7p5z//eW6NXqX0wAMPpPvvvz+9+eab6aGHHkrbb7992mWXXdKnn36aUmqZPVq8eHF64YUX0gsvvJAiIl188cXphRdeSG+//XZKqXY9OfbYY1OvXr3Sww8/nGbMmJH23HPPtP3226dVq1Y11MPKu5r6tGDBgvTCCy+ke++9N0VEuuWWW9ILL7yQ3n///dw+GkufhFKN1B//+MfUt2/f1KZNm/SVr3wlTZs2LXfboYcemoYNG5a7PmzYsBQRVS6HHnpo9oU3kLr063e/+13aeuutU7t27VLHjh3TjjvumC699NK0evXqBqi84dSlZ1/U0kKplOrWr1/96ldp8803T23btk0bb7xx+trXvpbuvffeBqi6YdX1OTZ79uy09957p+Li4tSrV680duzYtGzZsoyrbjh17dfHH3+ciouL0xVXXJFxpY1HXXv2u9/9Lg0ePDgVFxenHj16pB/96EfpnXfeybjq+vfFUGrNmjVp/PjxqXv37qmoqCh94xvfSC+99FLDFdgADjjggNSjR49UWFiYevbsmb773e+mWbNm5W7Xo8/87W9/S9tss00qKipKAwcOrPL/iz595sEHH0wRkebMmVPlNj36zKJFi9JJJ52U+vTpk9q2bZv69++fzjjjjFReXp5bo1cp3Xrrral///6pTZs2qXv37un444+v9MaCltijRx99dJ2vbWvTk+XLl6cTTjghde7cORUXF6dRo0al0tLSBng09aemPl199dVrvX38+PG5fTSWPhWk1ITfsw4AAABAk+QzpQAAAADInFAKAAAAgMwJpQAAAADInFAKAAAAgMwJpQAAAADInFAKAAAAgMwJpQAAAADInFAKAAAAgMwJpQAAAADInFAKAAAAgMwJpQAAAADInFAKAAAAgMz9Px36ZQPpXpNpAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 1200x500 with 2 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "ttft_values = [d[\"ttft_s\"] for d in individual_responses if \"ttft_s\" in d]\n",
+    "throughput_values = [d[\"request_output_throughput_token_per_s\"] for d in individual_responses if \"request_output_throughput_token_per_s\" in d]\n",
+    "\n",
+    "fig, axes = plt.subplots(1, 2, figsize=(12, 5))\n",
+    "axes[0].hist(ttft_values, bins=50, edgecolor=\"black\")\n",
+    "axes[0].set_title(\"Time to first token (s)\")\n",
+    "axes[1].hist(throughput_values, bins=50, edgecolor=\"black\")\n",
+    "axes[1].set_title(\"Request throughput (tokens/s)\")\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cdc0dad0-e704-496b-934f-e7795d5be9c7",
+   "metadata": {},
+   "source": [
+    "Feel free to edit the arguments of the `write_benchmarking_script` function to re-run the analysis for your specific scenario."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a76dc1d9-5f34-4e13-8864-5939b4c9fe9a",
+   "metadata": {},
+   "source": [
+    "## Clean up"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "id": "c64052fb-cfa8-4b7e-a2f3-55df3a2b124d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bedrock = boto3.client('bedrock', region_name=region)\n",
+    "response = bedrock.delete_imported_model(\n",
+    "    modelIdentifier=imported_model_name\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b6eeb654-818a-46c7-8961-0a716e7d48a1",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.16"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Added notebook that illustrates the process of using LLMPerf to run benchmarking tests on Bedrock custom imported models. This notebook uses DeepSeek R1 Distill Llama as the test model, and it leverages LiteLLM to translate the request/response formats.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
