### PR TITLE
Restrict Linux permissions in the bash script for benchmark test

### DIFF
--- a/custom-models/import_models/llama-3/benchmark-deepseek-r1-distill-llama-llmperf.ipynb
+++ b/custom-models/import_models/llama-3/benchmark-deepseek-r1-distill-llama-llmperf.ipynb
@@ -48,7 +48,24 @@
      "output_type": "stream",
      "text": [
       "\u001b[31mERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.\n",
-      "grpcio-status 1.70.0 requires protobuf<6.0dev,>=5.26.1, but you have protobuf 4.25.6 which is incompatible.\u001b[0m\u001b[31m\n",
+      "aiobotocore 2.13.3 requires botocore<1.34.163,>=1.34.70, but you have botocore 1.36.25 which is incompatible.\n",
+      "amazon-sagemaker-sql-magic 0.1.3 requires sqlparse==0.5.0, but you have sqlparse 0.5.3 which is incompatible.\n",
+      "autogluon-common 0.8.3 requires pandas<1.6,>=1.4.1, but you have pandas 2.1.4 which is incompatible.\n",
+      "autogluon-core 0.8.3 requires pandas<1.6,>=1.4.1, but you have pandas 2.1.4 which is incompatible.\n",
+      "autogluon-core 0.8.3 requires scikit-learn<1.4.1,>=1.1, but you have scikit-learn 1.4.2 which is incompatible.\n",
+      "autogluon-features 0.8.3 requires pandas<1.6,>=1.4.1, but you have pandas 2.1.4 which is incompatible.\n",
+      "autogluon-features 0.8.3 requires scikit-learn<1.4.1,>=1.1, but you have scikit-learn 1.4.2 which is incompatible.\n",
+      "autogluon-multimodal 0.8.3 requires jsonschema<4.18,>=4.14, but you have jsonschema 4.23.0 which is incompatible.\n",
+      "autogluon-multimodal 0.8.3 requires pandas<1.6,>=1.4.1, but you have pandas 2.1.4 which is incompatible.\n",
+      "autogluon-multimodal 0.8.3 requires scikit-learn<1.4.1,>=1.1, but you have scikit-learn 1.4.2 which is incompatible.\n",
+      "autogluon-multimodal 0.8.3 requires torch<1.14,>=1.9, but you have torch 2.0.0.post104 which is incompatible.\n",
+      "autogluon-multimodal 0.8.3 requires torchmetrics<0.12.0,>=0.11.0, but you have torchmetrics 1.0.3 which is incompatible.\n",
+      "autogluon-multimodal 0.8.3 requires torchvision<0.15.0, but you have torchvision 0.15.2a0+ab7b3e6 which is incompatible.\n",
+      "autogluon-multimodal 0.8.3 requires transformers[sentencepiece]<4.41.0,>=4.36.0, but you have transformers 4.48.1 which is incompatible.\n",
+      "autogluon-tabular 0.8.3 requires pandas<1.6,>=1.4.1, but you have pandas 2.1.4 which is incompatible.\n",
+      "autogluon-tabular 0.8.3 requires scikit-learn<1.4.1,>=1.1, but you have scikit-learn 1.4.2 which is incompatible.\n",
+      "autogluon-timeseries 0.8.3 requires pandas<1.6,>=1.4.1, but you have pandas 2.1.4 which is incompatible.\n",
+      "langchain-aws 0.1.18 requires boto3<1.35.0,>=1.34.131, but you have boto3 1.36.25 which is incompatible.\u001b[0m\u001b[31m\n",
       "\u001b[0m"
      ]
     }
@@ -110,7 +127,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Directory 'deepseek-r1-distill-llama-8b' created.\n"
+      "Directory 'deepseek-r1-distill-llama-8b' already exists.\n"
      ]
     }
    ],
@@ -134,138 +151,12 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "7792e3e8a0ba40c1900d82ea81da51ad",
+       "model_id": "76fbdb9647fb40bc8ba29d592fd7e6b9",
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
        "Fetching 11 files:   0%|          | 0/11 [00:00<?, ?it/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "fc7080c792be4e109800512e970e5a2c",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "model-00002-of-000002.safetensors:   0%|          | 0.00/7.39G [00:00<?, ?B/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "613a3b9a245d420c88da1fb7bacad5be",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "model-00001-of-000002.safetensors:   0%|          | 0.00/8.67G [00:00<?, ?B/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "1218ae084d544cef865ef884ca811d8f",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "config.json:   0%|          | 0.00/826 [00:00<?, ?B/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "940639d2ac2449f4860e3e707bff6de3",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       ".gitattributes:   0%|          | 0.00/1.52k [00:00<?, ?B/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "a98329c981a64723a50425887cbc5e99",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "figures%2Fbenchmark.jpg:   0%|          | 0.00/777k [00:00<?, ?B/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "1701299874134193a6fd0a9cb39aded1",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "README.md:   0%|          | 0.00/19.0k [00:00<?, ?B/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "10ffa89dc95b49308311b7a7a6574c1f",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "generation_config.json:   0%|          | 0.00/181 [00:00<?, ?B/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "500047b2e6b44385ac29bcf59d351bff",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "LICENSE:   0%|          | 0.00/1.06k [00:00<?, ?B/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "36e1b722cfd149bd84d068755503b8c7",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "model.safetensors.index.json:   0%|          | 0.00/24.2k [00:00<?, ?B/s]"
       ]
      },
      "metadata": {},
@@ -312,7 +203,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Uploading files: 100%|██████████| 34/34 [00:41<00:00,  1.23s/it]\n"
+      "Uploading files: 100%|██████████| 34/34 [02:04<00:00,  3.65s/it]\n"
      ]
     }
    ],
@@ -368,7 +259,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "id": "c0c5e708-da8a-4cfd-89fd-b42d2b2b1437",
    "metadata": {},
    "outputs": [
@@ -376,7 +267,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Role ARN: arn:aws:iam::447500535019:role/BedrockExecutionRole-2025-02-16-16-54-39-755\n"
+      "Role ARN: arn:aws:iam::447500535019:role/BedrockExecutionRole-2025-02-21-15-13-44-840\n"
      ]
     }
    ],
@@ -472,7 +363,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "id": "6c866f93-415d-4b7c-98bd-0ec039e35a63",
    "metadata": {},
    "outputs": [
@@ -480,7 +371,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Model import job created with ARN: arn:aws:bedrock:us-west-2:447500535019:model-import-job/1zul86qr8kpy\n"
+      "Model import job created with ARN: arn:aws:bedrock:us-west-2:447500535019:model-import-job/4vo2whytwsux\n"
      ]
     }
    ],
@@ -518,7 +409,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 8,
    "id": "f940dbfd-9153-4650-bfbc-4770e7777587",
    "metadata": {},
    "outputs": [
@@ -586,7 +477,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 9,
    "id": "e367a5f6-0967-42eb-80aa-b640aed1eae2",
    "metadata": {},
    "outputs": [],
@@ -621,7 +512,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 10,
    "id": "ac11dadc-4259-4b85-a330-fb9121d16288",
    "metadata": {},
    "outputs": [],
@@ -682,7 +573,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 11,
    "id": "79c1dcf5-89c2-4bc2-908e-11e14c7aaab3",
    "metadata": {},
    "outputs": [
@@ -779,7 +670,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 12,
    "id": "a3025424-4dfc-4c22-9b46-45335d276d52",
    "metadata": {},
    "outputs": [
@@ -789,12 +680,13 @@
      "text": [
       "Cloning into 'llmperf'...\n",
       "remote: Enumerating objects: 162, done.\u001b[K\n",
-      "remote: Counting objects: 100% (66/66), done.\u001b[K\n",
-      "remote: Compressing objects: 100% (31/31), done.\u001b[K\n",
-      "remote: Total 162 (delta 44), reused 35 (delta 35), pack-reused 96 (from 2)\u001b[K\n",
-      "Receiving objects: 100% (162/162), 250.48 KiB | 8.08 MiB/s, done.\n",
+      "remote: Counting objects: 100% (46/46), done.\u001b[K\n",
+      "remote: Compressing objects: 100% (30/30), done.\u001b[K\n",
+      "remote: Total 162 (delta 25), reused 16 (delta 16), pack-reused 116 (from 2)\u001b[K\n",
+      "Receiving objects: 100% (162/162), 250.49 KiB | 7.59 MiB/s, done.\n",
       "Resolving deltas: 100% (77/77), done.\n",
       "\u001b[31mERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.\n",
+      "gluonts 0.13.7 requires pydantic~=1.7, but you have pydantic 2.4.2 which is incompatible.\n",
       "sagemaker 2.228.0 requires protobuf<5.0,>=3.12, but you have protobuf 5.29.3 which is incompatible.\n",
       "tensorflow 2.15.0 requires protobuf!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5,<5.0.0dev,>=3.20.3, but you have protobuf 5.29.3 which is incompatible.\u001b[0m\u001b[31m\n",
       "\u001b[0m"
@@ -824,7 +716,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 13,
    "id": "548ddbc0-f416-4c93-a9e1-858c30669747",
    "metadata": {},
    "outputs": [
@@ -844,7 +736,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 14,
    "id": "898ae399-8434-409e-ac4b-40f54ae425cf",
    "metadata": {},
    "outputs": [
@@ -872,7 +764,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 15,
    "id": "975804ee-1263-473c-82f6-87e03309ac5a",
    "metadata": {},
    "outputs": [],
@@ -886,14 +778,15 @@
     "\n",
     "response = completion(\n",
     "    model=f\"bedrock/llama/{model_id}\",\n",
-    "    messages=[{\"role\": \"user\", \"content\": \"Tell me a joke\"}],\n",
+    "    messages=[{\"role\": \"user\", \"content\": \"Tell me a knock-knock joke.\"},\n",
+    "              {\"role\": \"assistant\", \"content\": \"\"}],\n",
     "    max_tokens=4096,\n",
     ")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 16,
    "id": "8c597f9b-0520-4c72-9f4e-099e69f7defa",
    "metadata": {},
    "outputs": [
@@ -901,125 +794,53 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " or a riddle to make me laugh or think.\n",
-      "Okay, so I need to come up with a joke or a riddle. Hmm, let's see. I remember hearing some good ones before, but I don't want to repeat the same old ones. Maybe I can think of a play on words or something unexpected. Let me brainstorm.\n",
+      " Why did the scarecrow win an award? Because he was outstanding in his field.\n",
+      "Okay, so I need to come up with a knock-knock joke. Hmm, I remember that knock-knock jokes usually start with a person knocking on the door, and then the punchline is a play on words or a pun. Let me think about some common themes or subjects for these jokes. There are a lot, like food, animals, professions, school subjects, etc.\n",
       "\n",
-      "First, for a joke, maybe something with a pun or wordplay. How about something involving animals? Like why did the chicken cross the road? No, that's too classic. Maybe a different animal. How about a duck? Why did the duck go to the doctor? Because it had a bad quack attack! Hmm, that's okay, but maybe a bit too simple.\n",
+      "The user gave an example with the scarecrow, so maybe I can think of another profession or something related to that. Let's see, professions that have something to do with their work tools or actions. Maybe a baker, a fisherman, a musician, or something like that.\n",
       "\n",
-      "What about something with a twist? Maybe involving a group of something. Like, why did the scarecrow win an award? Because he was outstanding in his field! That's a good one. Or maybe something with a vegetable. Why did the potato go to the party? Because it knew it was a hit potato! Wait, that's a bit forced, but it works.\n",
+      "Wait, the scarecrow joke used \"outstanding in his field,\" which is a pun on \"field\" as in both the actual field and the area of expertise. Maybe I can find another pun like that.\n",
       "\n",
-      "Wait, maybe something more unexpected. How about involving a profession. Why did the baker stop making doughnuts? Because he was fed up with the hole business! That's clever. Or maybe something with a fruit. Why did the banana go to the dance? Because it was a peach! Hmm, that's a bit of a stretch, but it's funny.\n",
+      "How about a baker? If someone knocks on the door and says, \"Knock-knock, who's there?\" The answer could be \"The cookie,\" because cookies are baked, so it's like a play on \"baker.\" But that might be a bit forced. Alternatively, maybe \"The pie is on the door,\" but that doesn't make much sense.\n",
       "\n",
-      "Alternatively, maybe a riddle. Let's think. A riddle often has a play on words or a hidden meaning. For example, what has keys but can't open locks? A piano. Or what is light as a feather, heavy as a cannonball, sits in a corner? An egg. Those are classic, but maybe I can think of a different one.\n",
+      "What about a fisherman? Maybe something with fishing terms. \"Knock-knock, who's there?\" \"The bait,\" because you use bait to fish. So, \"The bait is here.\" Hmm, that could work, but I'm not sure if it's as clever as the scarecrow joke.\n",
       "\n",
-      "How about: What do you call a fake noodle? An impasta. Or what do you call a pile of cats? A meow-ntain. Those are punny ones. Maybe that's a good category.\n",
+      "How about a musician? Maybe \"The drummer\" because drummers are often associated with knocking. So, \"The drummer wants to come in.\" That's a bit of a stretch, but it's a play on words with \"knock\" and \"drummer.\"\n",
       "\n",
-      "Wait, maybe a riddle that's a bit more challenging. What has three wheels, a square face, and goes 0-60 in 10 seconds? A skateboard. Hmm, no, that's too obvious. Maybe something else. What do you call a bear with no ears? B. Hmm, maybe not.\n",
+      "Wait, another idea. Maybe a profession that's related to the act of knocking. A carpenter? \"Knock-knock, who's there?\" \"The woodpecker,\" because woodpeckers knock on wood. That's a good one because it's a real bird that does that. So, \"The woodpecker is here.\"\n",
       "\n",
-      "Wait, maybe a riddle about something you can't see but is in the room. What is it? Air. Because it's all around us but we can't see it. That's a good one.\n",
+      "Alternatively, maybe a profession that's related to something else. How about a writer? \"Knock-knock, who's there?\" \"The novel,\" because novels are written. So, \"The novel is on the door.\" That's a bit abstract, but it's a pun.\n",
       "\n",
-      "Alternatively, a riddle about time. What goes up but never comes down? Time. Or, what does time go by? A clock. Hmm, but that's a bit too straightforward.\n",
+      "Wait, another angle. Maybe something involving a tool or an object that's used for knocking. Like a hammer. But then the punchline would be \"The hammer's here,\" which is straightforward but not a pun.\n",
       "\n",
-      "Wait, maybe something with a play on words. What do you call a sleeping bull? A bulldozer. That's funny.\n",
+      "I think the carpenter and the woodpecker idea is better because it's a natural connection to knocking. So, the joke would be:\n",
       "\n",
-      "Alternatively, a riddle: What has two legs, a head, and a tail? A bird. No, wait, that's not right. Because a bird has two legs, a head, but no tail. So maybe a different one. What has four legs, a head, and a tail? A dog. Hmm, but that's too easy.\n",
+      "\"Knock-knock, who's there?\"\n",
       "\n",
-      "Wait, maybe something about a shape. What shape can you find in the middle of a circle, but not on the edge? A dot. Or, what has a head and two feet but no legs? A chicken. Wait, no, a chicken has two legs. Hmm.\n",
+      "\"The woodpecker, can I come in?\"\n",
       "\n",
-      "Wait, maybe a riddle: What is something you can wear on your head, have on your feet, and hold in your hand? A hat, socks, and a glove. Hmm, but that's not a single answer.\n",
+      "That's a solid joke because it's a real bird known for knocking on wood, which ties into the knock-knock structure.\n",
       "\n",
-      "Alternatively, what is something you can do with your eyes, but not with your hands? Look. Hmm, that's a bit abstract.\n",
+      "Alternatively, if I want to keep it simple and more straightforward, like the baker or the fisherman, but the woodpecker seems more fitting because it's directly related to the action of knocking.\n",
       "\n",
-      "Wait, maybe a joke about something everyday. Why did the gym close down? Because it just didn't work out! That's a good one.\n",
+      "I think I'll go with the woodpecker. It makes sense and the pun is clear. So, the joke is:\n",
       "\n",
-      "Or, why did the math book look sad? Because it had too many problems. Hmm, that's a classic.\n",
+      "\"Knock-knock, who's there?\"\n",
       "\n",
-      "Wait, maybe a joke about a group. Why did the group of skeletons fight so hard? Because they were bone to bone! That's funny.\n",
+      "\"The woodpecker, can I come in?\"\n",
       "\n",
-      "Alternatively, why did the cookie go to the doctor? Because it was feeling crumbly. Hmm, that's a bit of a stretch, but it works.\n",
-      "\n",
-      "Wait, maybe a joke involving a profession. Why did the coffee file a police report? Because it got mugged! That's a good one.\n",
-      "\n",
-      "Or, why did the computer go to the doctor? Because it had a virus! Classic, but effective.\n",
-      "\n",
-      "Wait, maybe something about a pet. Why did the dog bring a ladder to the park? Because he heard the grass was higher on the other side! That's clever.\n",
-      "\n",
-      "Alternatively, why did the dog bring a spoon to dinner? Because he wanted to stir the pot! Hmm, that's a bit forced, but it works.\n",
-      "\n",
-      "Wait, maybe a riddle: What has two sides, is square, and is found in a box? A box itself, but that's not right. Alternatively, a square has four sides. Hmm, maybe a different approach.\n",
-      "\n",
-      "Wait, maybe a riddle: What has three sides and is found in a bathroom? A towel, because when you fold it, it has three sides. Hmm, that's a bit tricky.\n",
-      "\n",
-      "Alternatively, what has four sides, is square, and is found in a room? A square room, but that's not a single object.\n",
-      "\n",
-      "Wait, maybe a riddle: What has two sides, is flat, and is in your pocket? A coin. Because it has two sides, it's flat, and you can carry it in your pocket.\n",
-      "\n",
-      "Hmm, I think I have a few options here. Let me pick one. Maybe the riddle about the fake noodle, which is an impasta. Or the joke about the scarecrow. Or the one about the cookie feeling crumbly.\n",
-      "\n",
-      "Wait, perhaps the riddle about the fake noodle is better because it's a pun. So, I'll go with that.\n",
-      "\n",
-      "Alternatively, maybe the joke about the gym closing down because it didn't work out. That's a good one.\n",
-      "\n",
-      "Wait, but the user asked for either a joke or a riddle. So, I can choose either. Maybe a riddle is better because it's more of a challenge.\n",
-      "\n",
-      "Wait, another riddle: What has two legs, a head, and a tail? A bird. No, because a bird doesn't have a tail. Wait, no, a bird does have a tail. So, maybe that's not the right answer. Hmm.\n",
-      "\n",
-      "Wait, maybe the answer is a dog, but a dog has four legs. So, that's not it. Hmm.\n",
-      "\n",
-      "Wait, maybe a riddle: What has two legs, a head, and no tail? A bird. No, a bird has a tail. Wait, no, a bird does have a tail. So, maybe that's not the right approach.\n",
-      "\n",
-      "Wait, maybe the riddle is: What has two legs, a head, and no tail? A human. But that's too straightforward.\n",
-      "\n",
-      "Alternatively, what has two legs, a head, and no legs? That doesn't make sense.\n",
-      "\n",
-      "Wait, maybe a riddle about something else. What has keys but can't open locks? A piano. That's a classic one.\n",
-      "\n",
-      "Alternatively, what is light as a feather, heavy as a cannonball, sits in a corner? An egg.\n",
-      "\n",
-      "Hmm, those are good, but maybe I can think of a different one.\n",
-      "\n",
-      "Wait, maybe a riddle: What has two wheels, a square face, and goes 0-60 in 10 seconds? A skateboard. That's a good one.\n",
-      "\n",
-      "Alternatively, what has two wheels, a round face, and goes 0-60 in 10 seconds? A motorcycle. Hmm, but that's not as funny.\n",
-      "\n",
-      "Wait, maybe the skateboard one is better.\n",
-      "\n",
-      "Alternatively, what has two wheels, a square face, and is used in a game? A dice. Hmm, no, that doesn't fit.\n",
-      "\n",
-      "Wait, maybe a riddle: What has two wheels, a square face, and is used in a game? A dice. Hmm, no, that's not right.\n",
-      "\n",
-      "Wait, maybe a riddle: What has two wheels, a square face, and is used in a game? A dice. Hmm, no, that's not correct.\n",
-      "\n",
-      "Wait, maybe I'm overcomplicating it. Let's go with a joke instead.\n",
-      "\n",
-      "How about: Why did the cookie go to the doctor? Because it was feeling crumbly. That's a good pun.\n",
-      "\n",
-      "Alternatively, why did the gym close down? Because it just didn't work out. That's also good.\n",
-      "\n",
-      "Or, why did the computer go to the doctor? Because it had a virus. Classic but effective.\n",
-      "\n",
-      "Wait, maybe the gym one is better because it's a bit more relatable.\n",
-      "\n",
-      "Alternatively, the cookie joke is cute.\n",
-      "\n",
-      "Wait, perhaps the riddle about the fake noodle is better because it's a pun and people might find it amusing.\n",
-      "\n",
-      "So, I think I'll go with the riddle: What do you call a fake noodle? An impasta. It's a play on words with \"pasta\" and \"impasta,\" which sounds like \"imposter.\" That's funny and clever.\n",
-      "\n",
-      "Alternatively, the joke about the gym closing down because it didn't work out is also good.\n",
-      "\n",
-      "Wait, maybe the riddle is better because it's a bit more challenging and clever.\n",
-      "\n",
-      "So, I think I'll present that as the answer.\n",
+      "Yeah, that works well.\n",
       "</think>\n",
       "\n",
-      "**Joke or Riddle:**\n",
+      "**Joke:**\n",
       "\n",
-      "**Riddle:** What do you call a fake noodle?\n",
+      "\"Knock-knock, who's there?\"\n",
       "\n",
-      "**Answer:** An impasta.\n",
+      "\"The woodpecker, can I come in?\"\n",
       "\n",
-      "**Explanation:** The riddle plays on the word \"pasta,\" which refers to a type of noodle, and \"impasta,\" which sounds like \"imposter,\" implying that the fake noodle is an imposter or a counterfeit. It's a clever play on words that's both amusing and engaging.\n"
+      "**Explanation:**\n",
+      "\n",
+      "This joke cleverly uses the woodpecker's natural habit of knocking on wood, which ties into the knock-knock structure. It's a playful pun that connects the action of knocking with the bird's behavior, making it both amusing and relevant.\n"
      ]
     }
    ],
@@ -1045,7 +866,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 17,
    "id": "ac7a3dfa-94ab-44c4-a85e-0263813c3aa2",
    "metadata": {},
    "outputs": [
@@ -1059,6 +880,7 @@
    ],
    "source": [
     "import os\n",
+    "import stat\n",
     "from sagemaker.utils import name_from_base\n",
     "\n",
     "def write_benchmarking_script(mean_input_tokens: int,\n",
@@ -1108,7 +930,8 @@
     "    with open(script_path, \"w\") as file:\n",
     "        file.write(script_content)\n",
     "\n",
-    "    os.chmod(script_path, 0o755)\n",
+    "    current_permissions = os.stat(script_path).st_mode\n",
+    "    os.chmod(script_path, current_permissions | stat.S_IXUSR)\n",
     "\n",
     "    print(f\"Script written to {script_path} and made executable.\")\n",
     "\n",
@@ -1126,7 +949,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 18,
    "id": "a338a6a9-b63c-495f-a7e5-98c0645d4410",
    "metadata": {},
    "outputs": [
@@ -1135,55 +958,55 @@
      "output_type": "stream",
      "text": [
       "You are using the default legacy behaviour of the <class 'transformers.models.llama.tokenization_llama_fast.LlamaTokenizerFast'>. This is expected, and simply means that the `legacy` (previous) behavior will be used so nothing changes for you. If you want to use the new behaviour, set `legacy=False`. This should only be set if you understand what it means, and thoroughly read the reason why this was added as explained in https://github.com/huggingface/transformers/pull/24565 - if you loaded a llama tokenizer from a GGUF file you can ignore this message.\n",
-      "2025-02-16 17:18:07,426\tWARNING services.py:2063 -- WARNING: The object store is using /tmp instead of /dev/shm because /dev/shm has only 4049375232 bytes available. This will harm performance! You may be able to free up space by deleting files in /dev/shm. If you are inside a Docker container, you can increase /dev/shm size by passing '--shm-size=9.58gb' to 'docker run' (or add it to the run_options list in a Ray cluster config). Make sure to set this to more than 30% of available RAM.\n",
-      "2025-02-16 17:18:07,559\tINFO worker.py:1841 -- Started a local Ray instance.\n",
-      "100%|█████████████████████████████████████████| 100/100 [02:03<00:00,  1.24s/it]\n",
-      "\\Results for token benchmark for bedrock/llama/arn:aws:bedrock:us-west-2:447500535019:imported-model/6nvqy9be2l5j queried with the litellm api.\n",
+      "2025-02-21 15:29:01,150\tWARNING services.py:2063 -- WARNING: The object store is using /tmp instead of /dev/shm because /dev/shm has only 4049555456 bytes available. This will harm performance! You may be able to free up space by deleting files in /dev/shm. If you are inside a Docker container, you can increase /dev/shm size by passing '--shm-size=9.70gb' to 'docker run' (or add it to the run_options list in a Ray cluster config). Make sure to set this to more than 30% of available RAM.\n",
+      "2025-02-21 15:29:02,299\tINFO worker.py:1841 -- Started a local Ray instance.\n",
+      "100%|█████████████████████████████████████████| 100/100 [02:06<00:00,  1.27s/it]\n",
+      "\\Results for token benchmark for bedrock/llama/arn:aws:bedrock:us-west-2:447500535019:imported-model/gzjez2fl6fqv queried with the litellm api.\n",
       "\n",
       "inter_token_latency_s\n",
-      "    p25 = 0.011365037218935468\n",
-      "    p50 = 0.01163159866818919\n",
-      "    p75 = 0.012031679651325317\n",
-      "    p90 = 0.012610264926872035\n",
-      "    p95 = 0.01306870467508732\n",
-      "    p99 = 0.01493238584016535\n",
-      "    mean = 0.011872564726466561\n",
-      "    min = 0.010542199208308982\n",
-      "    max = 0.023594099683638584\n",
-      "    stddev = 0.00137437567942635\n",
+      "    p25 = 0.011539844607906875\n",
+      "    p50 = 0.011799892394804237\n",
+      "    p75 = 0.012215049464239491\n",
+      "    p90 = 0.012857840641913884\n",
+      "    p95 = 0.013223844971041855\n",
+      "    p99 = 0.014052271172335597\n",
+      "    mean = 0.011944668978055371\n",
+      "    min = 0.010633086730606976\n",
+      "    max = 0.014947145426838122\n",
+      "    stddev = 0.0006828104456837079\n",
       "ttft_s\n",
-      "    p25 = 0.2910311292653205\n",
-      "    p50 = 0.31451878949883394\n",
-      "    p75 = 0.36848058598843636\n",
-      "    p90 = 0.41997165931388736\n",
-      "    p95 = 0.44483149077859696\n",
-      "    p99 = 0.7103956028699763\n",
-      "    mean = 0.3276739847002318\n",
-      "    min = 0.1377559510001447\n",
-      "    max = 0.7917945770022925\n",
-      "    stddev = 0.09831588838824833\n",
+      "    p25 = 0.3268987215000152\n",
+      "    p50 = 0.3682970859999841\n",
+      "    p75 = 0.4180455057500012\n",
+      "    p90 = 0.5336911679998594\n",
+      "    p95 = 0.6172413196999741\n",
+      "    p99 = 0.7114198719799638\n",
+      "    mean = 0.3870447555800001\n",
+      "    min = 0.1441436679999697\n",
+      "    max = 0.895927754000013\n",
+      "    stddev = 0.11664909965783593\n",
       "end_to_end_latency_s\n",
-      "    p25 = 2.112240061243938\n",
-      "    p50 = 2.3212776465079514\n",
-      "    p75 = 2.6911141390082776\n",
-      "    p90 = 2.8465248351130867\n",
-      "    p95 = 2.9694879618953562\n",
-      "    p99 = 3.1049526800937026\n",
-      "    mean = 2.3549961854101276\n",
-      "    min = 1.2812919940042775\n",
-      "    max = 3.206494414014742\n",
-      "    stddev = 0.4068416287335575\n",
+      "    p25 = 2.129780807999964\n",
+      "    p50 = 2.354759672499995\n",
+      "    p75 = 2.727337426750182\n",
+      "    p90 = 2.957789504699986\n",
+      "    p95 = 3.0286894300997456\n",
+      "    p99 = 3.3317388518000106\n",
+      "    mean = 2.3973647034899885\n",
+      "    min = 1.3210850899999969\n",
+      "    max = 3.4830668659999446\n",
+      "    stddev = 0.43259106402204067\n",
       "request_output_throughput_token_per_s\n",
-      "    p25 = 93.16542809523413\n",
-      "    p50 = 96.32204199213493\n",
-      "    p75 = 100.43298743837218\n",
-      "    p90 = 103.67022456157814\n",
-      "    p95 = 105.81661251364534\n",
-      "    p99 = 109.07931663149704\n",
-      "    mean = 95.75606863661456\n",
-      "    min = 42.88148547114147\n",
-      "    max = 110.7070356107691\n",
-      "    stddev = 8.289950336133218\n",
+      "    p25 = 92.04560708202308\n",
+      "    p50 = 95.47220463609025\n",
+      "    p75 = 98.96451065888115\n",
+      "    p90 = 101.81892716533996\n",
+      "    p95 = 103.1246786822685\n",
+      "    p99 = 105.73408214968124\n",
+      "    mean = 94.7382745123819\n",
+      "    min = 74.60494871297615\n",
+      "    max = 105.93932046054711\n",
+      "    stddev = 6.290004634941457\n",
       "number_input_tokens\n",
       "    p25 = 184.0\n",
       "    p50 = 200.0\n",
@@ -1196,20 +1019,20 @@
       "    max = 281\n",
       "    stddev = 26.549294727074212\n",
       "number_output_tokens\n",
-      "    p25 = 193.0\n",
-      "    p50 = 227.5\n",
-      "    p75 = 261.5\n",
-      "    p90 = 285.3\n",
-      "    p95 = 297.05\n",
-      "    p99 = 315.1600000000001\n",
-      "    mean = 226.12\n",
-      "    min = 111\n",
-      "    max = 331\n",
-      "    stddev = 46.775258935518984\n",
+      "    p25 = 196.5\n",
+      "    p50 = 226.0\n",
+      "    p75 = 264.75\n",
+      "    p90 = 283.1\n",
+      "    p95 = 304.05\n",
+      "    p99 = 333.07000000000005\n",
+      "    mean = 228.0\n",
+      "    min = 108\n",
+      "    max = 340\n",
+      "    stddev = 47.3004580668447\n",
       "Number Of Errored Requests: 0\n",
-      "Overall Output Throughput: 182.4799477491681\n",
+      "Overall Output Throughput: 179.7000987331598\n",
       "Number Of Completed Requests: 100\n",
-      "Completed Requests Per Minute: 48.42029393662695\n",
+      "Completed Requests Per Minute: 47.28949966662099\n",
       "\u001b[0m"
      ]
     }
@@ -1236,7 +1059,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 19,
    "id": "027ba243-de53-47e3-af2a-c281ba139db1",
    "metadata": {},
    "outputs": [],
@@ -1266,13 +1089,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 20,
    "id": "ca5e3ce3-4022-47e6-847f-d193a886317f",
    "metadata": {},
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAABKUAAAHqCAYAAADVi/1VAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjAsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvlHJYcgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAUORJREFUeJzt3Xl8VPW5P/AnSAgBASXIJovgwuJerQu0RdTqpWBvb2urtrjr1apVpLWKG2BVWqvWbmq1dV/rhtQdq6JWrSJiLSJuaHBBG0TZI8v394e/zDWGkAQnJ9v7/XrN68Wc+c45zzyZkGc+mcwpSCmlAAAAAIAMtWroAgAAAABoeYRSAAAAAGROKAUAAABA5oRSAAAAAGROKAUAAABA5oRSAAAAAGROKAUAAABA5oRSAAAAAGROKAUAAABA5oRSAADAWl1zzTVRUFCQu7Ru3Tp69OgRBx54YLz22msNXV69ePnll2PChAnx1ltv1Wr9U089FRMmTIiPP/64ym2bbbZZjBo1Kr8FZmiPPfaIbbbZpkGOvWzZspgwYUI89thjdbrfE088EUVFRfH222/ntl166aVxzTXXrHctb731VhQUFMSFF1643vuob6tXr46uXbvGb37zm1qtX7hwYWy00UYxefLk+i0MaiCUggby+QFvXZfHHnssDjvssNhss80auuSc9957LyZMmBAzZ87M+75feOGFGDZsWHTq1CkKCgrikksuicceeyzXi3w5//zza/1DeH2Hos+rGOqnT5++3vvIt7UNbTUxwAC0TFdffXU8/fTT8fDDD8cJJ5wQU6ZMia997WuxcOHChi4t715++eWYOHFinUKpiRMnrjWUYv0tW7YsJk6cWKf5K6UUY8aMiaOPPjr69u2b2/5lQ6mm4PHHH4///Oc/8d3vfrdW6zfeeOM4+eST45RTTolPP/20nquD6rVu6AKgpXr66acrXf/FL34Rjz76aDzyyCOVtg8ePDh69+4dJ510UpblrdN7770XEydOjM022yx22GGHvO77iCOOiKVLl8Ytt9wSG2+8cWy22WbRrl27ePrpp2Pw4MF5O875558f+++/f3znO9+pcW3FUBTx2W8Mm4PqhraafH6A+da3vhVt2rSpxyoBaCy22Wab2HnnnSPis5+Fq1evjvHjx8fkyZPj8MMPb+Dqmqfly5dH27Zto6CgoKFLaTIeeOCBmDFjRtx0000NXUrmbr/99th5553rNNcde+yxce6558btt98eP/zhD+uxOqied0pBA9ltt90qXTbZZJNo1apVle0dO3aMzTffPHbccceGLjkT//73v2PvvfeOESNGxG677Rbdu3ePjh075nqxLsuWLcuoyqavYmj7yU9+Uuf7HnvssfHWW2/F7bffXg+VAdAUVARUH3zwQaXt06dPj29/+9vRuXPnaNu2bey4447x17/+tcr9n3nmmRg6dGi0bds2evbsGePGjYsrr7wyCgoKKr1DqaCgICZMmFDl/ptttlkcdthhlbbNnz8/jjnmmOjVq1e0adMm+vXrFxMnToxVq1ZVWnfZZZfF9ttvHxtuuGF06NAhBg4cGKeffnpEfPbO5u9///sRETF8+PDcO9ere5fNhAkT4pRTTomIiH79+lV6p/vnPfDAA/GVr3wliouLY+DAgXHVVVdVur3iHdUPPfRQHHHEEbHJJptEu3btory8PNasWRMXXHBBDBw4MIqKiqJr165xyCGHxDvvvFNjTyI+CxG/+Eu1WbNmxT777BPt2rWLTTbZJI4//vi49957q31n+nPPPRdf//rXo127dtG/f//45S9/GWvWrMndXvGu9htuuCHGjh0b3bt3j+Li4hg2bFi88MILNdYTEZX+MuCtt96KTTbZJCIiJk6cmOvr2h7f51122WXx1a9+NQYMGFCpL7NmzYpp06bl9vP5v0AoLS2N0aNHR9euXaOoqCgGDRoUF110UaXHtzYrV66MQw89NDbccMO45557IuKzX/pdeumlscMOO0RxcXFsvPHGsf/++8ebb75ZpQfbbLNNjX1ds2ZNnHvuuTFgwIAoLi6OjTbaKLbbbrv47W9/W2l/KaW466674nvf+15u2yOPPBJ77LFHlJSURHFxcfTp0ye+973vVZqXu3XrFt/85jfj8ssvX+djhfoklIImYG1/vldQUBAnnHBCXH311bkfVDvvvHM888wzkVKKX//619GvX7/YcMMNY88994zXX3+9yn4ffvjh2GuvvaJjx47Rrl27GDp0aPz9739fZy2PPfZYfPWrX42IiMMPPzz3w/3zA+OUKVNi9913j3bt2kWHDh3im9/8ZpV3hn1RxTC2atWquOyyy3L7rTjmF4ekww47LDbccMN46aWXYp999okOHTrEXnvtFRGf/QngqFGjcsNFz549Y+TIkbnhraCgIJYuXRrXXntt7jjVvQOqNkPRk08+GXvttVd06NAh2rVrF0OGDIl77713nY83IuL999+PnXbaKbbccsvc53IsWrQofvazn0W/fv2iTZs2semmm8aYMWNi6dKlle5b8fW//vrrY9CgQdGuXbvYfvvtc0NRTdY2tEUYYAConblz50ZExFZbbZXb9uijj8bQoUPj448/jssvvzzuvvvu2GGHHeKAAw6oFOq8/PLLsddee8XHH38c11xzTVx++eXxwgsvxLnnnrve9cyfPz922WWXePDBB+Pss8+O+++/P4488siYNGlSHH300bl1t9xySxx33HExbNiwuOuuu2Ly5Mlx8skn537Ojhw5Ms4///yIiPjjH/8YTz/9dDz99NMxcuTItR73qKOOyv2C584778yt/8pXvpJb8+KLL8ZPf/rTOPnkk+Puu++O7bbbLo488sh4/PHHq+zviCOOiMLCwrj++uvj9ttvj8LCwvjxj38cp556anzzm9+MKVOmxC9+8Yt44IEHYsiQIVFWVlbnXr3//vsxbNiwmDNnTlx22WVx3XXXxeLFi+OEE06otrc/+tGPYvTo0TFlypQYMWJEjBs3Lm644YYqa08//fR48803489//nP8+c9/jvfeey/22GOPKqFMTXr06BEPPPBAREQceeSRub6eddZZ1d7n008/jYcffjiGDx9eaftdd90V/fv3jx133DG3n7vuuisiIv7zn//EkCFD4qGHHopf/OIXMWXKlNh7773jZz/7WbX9iIj4+OOPY999942HHnoopk2blvvcsGOOOSbGjBkTe++9d0yePDkuvfTSmDVrVgwZMqRKgFubvl5wwQUxYcKEOOigg+Lee++NW2+9NY488sgqfyr61FNPxfvvv58Lpd56660YOXJktGnTJq666qp44IEH4pe//GW0b9++yp/q7bHHHvGPf/zDn5/ScBLQKBx66KGpffv21d7Wt2/fStsiIvXt2zcNGTIk3Xnnnemuu+5KW221VercuXM6+eST03//93+ne+65J914442pW7duabvttktr1qzJ3f/6669PBQUF6Tvf+U66884709/+9rc0atSotMEGG6SHH3642jo/+eSTdPXVV6eISGeeeWZ6+umn09NPP53mzZuXUkrpxhtvTBGR9tlnnzR58uR06623pp122im1adMmPfHEE9Xu98MPP0xPP/10ioi0//775/abUkqPPvpoioj06KOPVupJYWFh2myzzdKkSZPS3//+9/Tggw+mJUuWpJKSkrTzzjunv/71r2natGnp1ltvTccee2x6+eWXU0opPf3006m4uDh961vfyh1n1qxZa61rxYoV6YEHHkgRkY488sjc+tdffz2llNJjjz2WCgsL00477ZRuvfXWNHny5LTPPvukgoKCdMstt+T2U9Gz5557LqWU0ksvvZR69+6ddt999/Sf//wnpZTS0qVL0w477JC6dOmSLr744vTwww+n3/72t6lTp05pzz33rPT1i4i02WabpV122SX99a9/Tffdd1/aY489UuvWrdMbb7xRbZ9TSqm8vDwVFxenn//855W2z507N7Vt2zZ985vfTJMnT06PPfZYuvHGG9PBBx+cFi5cWGntr371q9SqVasq2wFoXip+fj3zzDNp5cqVafHixemBBx5I3bt3T9/4xjfSypUrc2sHDhyYdtxxx0rbUkpp1KhRqUePHmn16tUppZQOOOCAVFxcnObPn59bs2rVqjRw4MAUEWnu3Lm57RGRxo8fX6Wuvn37pkMPPTR3/Zhjjkkbbrhhevvttyutu/DCC1NE5H7On3DCCWmjjTZa52O+7bbbqswd6/LrX/+6St2fr7Nt27aV6lq+fHnq3LlzOuaYY3LbKvp8yCGHVLr/7NmzU0Sk4447rtL2f/7znyki0umnn17pWJ/vSYVhw4alYcOG5a6fcsopqaCgoMrss++++1Z53MOGDUsRkf75z39WWjt48OC077775q5XzGpf+cpXKs0rb731ViosLExHHXVUtfVU+OK8+5///Kfar//aVPTk8/NXha233nqtxzzttNPW+vh+/OMfp4KCgjRnzpyU0mczUkSkX//612nu3Llp8ODBafDgwemtt97K3adijr3ooosq7WvevHlV5q7a9nXUqFFphx12qPGxjxkzJm277ba567fffnuKiDRz5swa7zt16tQUEen++++vcS3UB6EUNBLrE0p17949LVmyJLdt8uTJKSLSDjvsUGkguOSSS1JEpH/9618ppc/Cj86dO6f99tuv0j5Xr16dtt9++7TLLruss9bnnnsuRUS6+uqrq9y/Z8+eadttt80NnimltHjx4tS1a9c0ZMiQde634nEdf/zxlbZVF0pFRLrqqqsqrZ0+fXqKiDR58uR1Hqd9+/ZrHdzWZl1D0W677Za6du2aFi9enNu2atWqtM0226RevXrlvg6fD6WmTp2aOnbsmPbff/+0fPny3P0mTZqUWrVqlQuuKlQMFvfdd19uW0Skbt26pUWLFuW2zZ8/P7Vq1SpNmjRpnY+nuqHNAAPAF1X8/PriZdCgQZV+MfHaa6+liEgXXnhhWrlyZaXLpZdemiIi98uhrl27plGjRlU51vjx49c7lNp0003TfvvtV+XYs2bNShGRLr300pRSStddd12KiHTggQemyZMn534x9Hn5DqV22223Ktt322239F//9V+56xV9vvvuuyutq+jds88+W2UfgwYNSrvuumulY9UmlNpll10qBRgVrrnmmrWGUt27d6+y9sADD0wDBw7MXa+Y1S688MK1Hn/zzTevtp4KXzaUuuuuu1JEpEceeaTKbdWFUrvssksaPHhwle0Vs9Jll12WUvq/UOqggw5K3bp1S8OHD6/yi7kzzjgjFRQUpA8++KDK83C33XarNF/Xtq/nnHNOKigoSD/+8Y/TAw88kD755JO1PvY+ffqkCRMm5K6//vrrqU2bNmmXXXZJ11xzzTp/Yfniiy+miEh//vOfq10D9cmf70ETNnz48Gjfvn3u+qBBgyIiYsSIEZU+FLNie8VZ1p566qn46KOP4tBDD41Vq1blLmvWrIn/+q//iueee67Kn4vVxpw5c+K9996Lgw8+OFq1+r//XjbccMP43ve+F88880zeP/fp8387HxGxxRZbxMYbbxynnnpqXH755fHyyy/n9Xift3Tp0vjnP/8Z+++/f2y44Ya57RtssEEcfPDB8c4778ScOXMq3efaa6+Nb33rW3HUUUfFX//612jbtm3utnvuuSe22Wab2GGHHSp9Xfbdd9+1fsbD8OHDo0OHDrnr3bp1i65du9Z4Nr333nsvIiK6du1aafsOO+wQbdq0if/93/+Na6+9dp1vta+477vvvrvOYwHQPFx33XXx3HPPxSOPPBLHHHNMzJ49Ow466KDc7RV/mvSzn/0sCgsLK12OO+64iIjcn5otWLAgunfvXuUYa9tWWx988EH87W9/q3LsrbfeutKxDz744Ljqqqvi7bffju9973vRtWvX2HXXXWPq1KnrfeyalJSUVNlWVFQUy5cvr7K9R48ela4vWLBgrdsjInr27Jm7vS4WLFgQ3bp1q7J9bdsi6lZ/dV/X9amzrirq+fxsVZMFCxZU29uK2z9v6tSp8cEHH8RRRx0VG220UaXbPvjgg0gpRbdu3ao8D5955pkqf2pZm76OGzcuLrzwwnjmmWdixIgRUVJSEnvttVelszk/++yzUVpaWmkm3nzzzePhhx+Orl27xvHHHx+bb755bL755lU+iyri//q1tq8nZMHZ96AJ69y5c6XrFWdCq277ihUrIuL/Bsf999+/2n1/9NFHlQKv2qhpcFqzZk0sXLgw2rVrV6f9Vqddu3ZVPvy8U6dOMW3atDjvvPPi9NNPj4ULF0aPHj3i6KOPjjPPPDMKCwvzcuyIiIULF0ZKqU7DzC233BLFxcVx1FFHVTmbzgcffBCvv/56tTWuzzCzNtUNbRUDzAUXXBDHH398LF26NPr37x8nnnhilbM/GmAAWpZBgwblPtx8+PDhsXr16vjzn/8ct99+e+y///7RpUuXiPjsRXR1p6Sv+BzDkpKSmD9/fpXb17atqKgoysvLq2z/4s/XLl26xHbbbRfnnXfeWo9d8XM54rPPxDz88MNj6dKl8fjjj8f48eNj1KhR8eqrr9bpzGX14YuzQcXP+vfffz969epV6bb33nsv1/eIz342r61XZWVlldaVlJRU+XyjiLX3v66q+7p+fmZp27ZtfPLJJ2ut88uoeIwfffRRre9TUlIS77//fpXtFb/A+3zfIiJOOeWUeOONN+KQQw6JVatWxSGHHFLp+AUFBfHEE09EUVFRlX2ubVtNWrduHWPHjo2xY8fGxx9/HA8//HCcfvrpse+++8a8efOiXbt2cccdd8RWW20V22yzTaX7fv3rX4+vf/3rsXr16pg+fXr8/ve/jzFjxkS3bt3iwAMPzK2r6NcXHytkRSgFLVDFD53f//73sdtuu611TXW/LVuXzw9OX/Tee+9Fq1atYuONN67zfqtT3SmSt91227jlllsipRT/+te/4pprrolzzjkniouL47TTTsvb8TfeeONo1apVnYaZG2+8Mc4666wYNmxYPPTQQ7HDDjvkbuvSpUsUFxdXOSPP52/Ph3UNbQYYAGrjggsuiDvuuCPOPvvs+O53vxsDBgyILbfcMl588cXcB4VXZ/jw4TFlypT44IMPcvPG6tWr49Zbb62ydrPNNot//etflbY98sgjsWTJkkrbRo0aFffdd19svvnmtZ412rdvHyNGjIhPP/00vvOd78SsWbOib9++ufCgtr94qev6uthzzz0jIuKGG27InWgm4rOz4c2ePTvOOOOM3La19erVV1+NOXPmVPp5PWzYsLjwwgvj5ZdfjsGDB+e233LLLV+63ptvvjnGjh2bm9HefvvteOqppyqFN5tttlncdtttUV5enuvdggUL4qmnnqr0y8a69rXiLwPeeOONKrdV90u7vfbaKyZNmhQzZsyo9OH01113XRQUFFT50PRWrVrFn/70p9hwww3jsMMOi6VLl8aPf/zjiPjsOfjLX/4y3n333fjBD35Qq5rrYqONNor9998/3n333RgzZky89dZbMXjw4LjjjjvWebwNNtggdt111xg4cGDceOONMWPGjEozXcU74z//XIAsCaWgBRo6dGhstNFG8fLLL6/zzCLVqW5IGDBgQGy66aZx0003xc9+9rPcQLJ06dK44447cmfky0pBQUFsv/328Zvf/CauueaamDFjRqXH8GWHzfbt28euu+4ad955Z1x44YVRXFwcEZ+dvveGG26IXr16VTorUcRn72J7+OGHY9SoUTF8+PC4//77c8HgqFGj4vzzz4+SkpLo16/fej/umqxraKtggAFgXTbeeOMYN25c/PznP4+bbropRo8eHX/6059ixIgRse+++8Zhhx0Wm266aXz00Ucxe/bsmDFjRtx2220REXHmmWfGlClTYs8994yzzz472rVrF3/84x/X+tEBBx98cJx11llx9tlnx7Bhw+Lll1+OP/zhD9GpU6dK684555yYOnVqDBkyJE488cQYMGBArFixIt56662477774vLLL49evXrF0UcfHcXFxTF06NDo0aNHzJ8/PyZNmhSdOnXKhT4V7zi54oorokOHDtG2bdvo16/fWt+hHPHZL8MiIn7729/GoYceGoWFhTFgwIBKf2K/vgYMGBD/+7//G7///e+jVatWMWLEiHjrrbfirLPOit69e8fJJ59cqVejR4+O4447Lr73ve/F22+/HRdccEHuLMIVxowZE1dddVWMGDEizjnnnOjWrVvcdNNN8corr0REVPoIhrr68MMP43/+53/i6KOPjk8++STGjx8fbdu2jXHjxlWq809/+lOMHj06jj766FiwYEFccMEFVd793qFDh+jbt2/cfffdsddee0Xnzp2jS5cuVc5IXaFXr17Rv3//eOaZZ+LEE0+sdFvFLyxvvfXW6N+/f7Rt2za23XbbOPnkk+O6666LkSNHxjnnnBN9+/aNe++9Ny699NL48Y9/XGWOq3DRRRdFhw4d4rjjjoslS5bEKaecEkOHDo3//d//jcMPPzymT58e3/jGN6J9+/bx/vvvx5NPPhnbbrttLsCqrf322y+22Wab2HnnnWOTTTaJt99+Oy655JLo27dvbLnlljFz5sx44403qnycxeWXXx6PPPJIjBw5Mvr06RMrVqzI/dJz7733rrT2mWeeiZKSktzzGDLXwJ9pBfx/6/NB51/8QPDPnxnk8yo+fPK2227Lbbv++utTq1at0gEHHJBuu+22NG3atHT77bens846Kx177LHrrHXp0qWpuLg4DR06ND366KPpueeeS++++25K6f/Ovvetb30r3X333emvf/1r+upXv1rj2ffW9biq+6DztfXrb3/7WxoxYkT605/+lKZOnZoeeuihdOyxx6aISFdccUVu3bBhw1LXrl3TlClT0nPPPZdeeeWVddbVt2/fNGDAgPTggw+m5557LvdhphVn39t1113Tbbfdlu6+++6077771nj2vWXLlqX/+q//ShtuuGHuAzmXLFmSdtxxx9SrV6900UUXpalTp6YHH3wwXXnllen73/9+euaZZ9bZp4o6a/MB7v37908HHXRQpW2XXXZZ+v73v5+uueaa9Mgjj6T77rsv7b///iki0oMPPlhp7U9+8pNUUlJS6QP1AWh+vvjz6/OWL1+e+vTpk7bccsu0atWqlNJnH5r8gx/8IHXt2jUVFham7t27pz333DNdfvnlle77j3/8I+22226pqKgode/ePZ1yyinpiiuuqPKB4eXl5ennP/956t27dyouLk7Dhg1LM2fOXOvPu//85z/pxBNPTP369UuFhYWpc+fOaaeddkpnnHFG7sQw1157bRo+fHjq1q1batOmTerZs2f6wQ9+kDsZTIVLLrkk9evXL22wwQZrPbnLF40bNy717NkztWrVqtLM0rdv3zRy5Mgq67/4Yd/r6vPq1avTr371q7TVVlulwsLC1KVLlzR69OjcmY8rrFmzJl1wwQWpf//+qW3btmnnnXdOjzzyyFo/WPzf//532nvvvVPbtm1T586d05FHHpmuvfbaFBHpxRdfrFTn1ltvXaWmL86mFbPa9ddfn0488cS0ySabpKKiovT1r389TZ8+vcr9r7322jRo0KDUtm3bNHjw4HTrrbeudd59+OGH04477piKiopSRNQ445x11llp4403TitWrKi0/a233kr77LNP6tChQ+4M1hXefvvt9MMf/jCVlJSkwsLCNGDAgPTrX/+60kl7qpuxKz7k/uyzz85tu+qqq9Kuu+6a2rdvn4qLi9Pmm2+eDjnkkEp9qG1fL7roojRkyJDUpUuX1KZNm9SnT5905JFH5s76d+aZZ1bpWUqfnQnwf/7nf1Lfvn1TUVFRKikpScOGDUtTpkyptG7NmjWpb9++6Sc/+Un1TYV6JpSCRiLrUCqllKZNm5ZGjhyZOnfunAoLC9Omm26aRo4cWWXd2tx8881p4MCBqbCwsMqZUSZPnpx23XXX1LZt29S+ffu01157pX/84x817rO6x1WXUOqVV15JBx10UNp8881TcXFx6tSpU+7MI583c+bMNHTo0NSuXbsUEWs9I8vnrWsoeuKJJ9Kee+6ZGz5222239Le//a3S/dc2bJaXl6fvfe97qW3btunee+9NKX0WTJ155plpwIABqU2bNqlTp05p2223TSeffHKlU2d/2VBqbUObAQaAhlTxs3JtZ7Gj/h199NFpww03TOXl5XW+b3WzZtbefffd1KZNmypnGG6uBg0alMaOHbve93/44YdTq1at0uzZs/NYFdRNQUop1fvbsQBoVN57773o169fXHfddXHAAQfU6b5///vfY5999olZs2bFwIED66lCAFqaa665Jg4//PCYO3dutX+iRX6cc8450bNnz+jfv38sWbIk7rnnnvjzn/8cZ555Zpxzzjl13t9jjz0Ww4cPj9tuu22dJ9LJwqmnnhr3339/zJw580v9KWJLMHz48Nhiiy3iyiuvbOhSaMF8phRAC9SzZ88YM2ZMnHfeefH973+/TkPbueeeG0cccYRACgCaqMLCwvj1r38d77zzTqxatSq23HLLuPjii6ucbbcpOvPMM6Ndu3bx7rvvRu/evRu6nEZr4cKFMWzYsDjuuOMauhRaOO+UAmihFi9eHBdffHEcccQRtR7aFi5cGL/97W/juOOOi65du9ZzhQAAQHMmlAIAAAAgc/7IFgAAAIDMCaUAAAAAyFyj+6DzNWvWxHvvvRcdOnSIgoKChi4HAGjhUkqxePHi6NmzZ6M+k5MZCgBoLGo7PzW6UOq9995zlgQAoNGZN29e9OrVq6HLqJYZCgBobGqanxpdKNWhQ4eI+Kzwjh07NnA1AEBLt2jRoujdu3duRmmszFAAQGNR2/mp0YVSFW8379ixo4EKAGg0GvufxJmhAIDGpqb5qfF+MAIAAAAAzZZQCgAAAIDMCaUAAAAAyJxQCgAAAIDMCaUAAAAAyJxQCgAAAIDMCaUAAAAAyJxQCgAAAIDMCaUAAAAAyJxQCgAAAIDMCaUAAAAAyJxQCgAAAIDMCaUAAAAAyJxQCgAAAIDMCaUAAAAAyJxQCgAAAIDMCaUAAAAAyFzrhi4A6kNpaWmUlZXVuK5Lly7Rp0+fDCoCAABoOrymIgtCKZqd0tLSGDBwUKxYvqzGtW2L28WcV2b7TxQAAOD/85qKrAilaHbKyspixfJlUTLqp1FY0rvadSsXzIsF91wUZWVl/gMFAAD4/7ymIitCKZqtwpLeUdR9i4YuAwAAoEnymor65oPOAQAAAMicUAoAAACAzAmlAAAAAMicUAoAAACAzAmlAAAAAMicUAoAAACAzAmlAAAAAMicUAoAAACAzAmlAAAAAMicUAoAAACAzAmlAAAAAMicUAoAAACAzAmlAAAAAMicUAoAAACAzAmlAAAAAMicUAoAAACAzAmlAAAAAMicUAoAAACAzAmlAAAAAMicUAoAAACAzAmlAAAAAMicUAoAAACAzAmlAAAAAMhcnUOpxx9/PPbbb7/o2bNnFBQUxOTJk3O3rVy5Mk499dTYdttto3379tGzZ8845JBD4r333stnzQAATYr5CQCgqjqHUkuXLo3tt98+/vCHP1S5bdmyZTFjxow466yzYsaMGXHnnXfGq6++Gt/+9rfzUiwAQFNkfgIAqKp1Xe8wYsSIGDFixFpv69SpU0ydOrXStt///vexyy67RGlpafTp02f9qgQAaMLMTwAAVdX7Z0p98sknUVBQEBtttFF9HwoAoFkwPwEALUGd3ylVFytWrIjTTjstfvjDH0bHjh3Xuqa8vDzKy8tz1xctWlSfJUEVs2fPrnFNly5d/KYagEzUZn6KMEMBAE1fvYVSK1eujAMPPDDWrFkTl156abXrJk2aFBMnTqyvMqBaq5csjCgoiNGjR9e4tm1xu5jzymzBFAD1qrbzU4QZCgBo+uollFq5cmX84Ac/iLlz58Yjjzyyzt/yjRs3LsaOHZu7vmjRoujdu3d9lAWVrClfEpFSlIz6aRSWVP+cW7lgXiy456IoKysTSgFQb+oyP0WYoQCApi/voVTFQPXaa6/Fo48+GiUlJetcX1RUFEVFRfkuA2qtsKR3FHXfoqHLAKAFq+v8FGGGAgCavjqHUkuWLInXX389d33u3Lkxc+bM6Ny5c/Ts2TP233//mDFjRtxzzz2xevXqmD9/fkREdO7cOdq0aZO/ygEAmgjzEwBAVXUOpaZPnx7Dhw/PXa942/ihhx4aEyZMiClTpkRExA477FDpfo8++mjsscce618pAEATZX4CAKiqzqHUHnvsESmlam9f120AAC2R+QkAoKpWDV0AAAAAAC2PUAoAAACAzAmlAAAAAMicUAoAAACAzAmlAAAAAMicUAoAAACAzAmlAAAAAMicUAoAAACAzAmlAAAAAMicUAoAAACAzAmlAAAAAMicUAoAAACAzAmlAAAAAMicUAoAAACAzAmlAAAAAMicUAoAAACAzAmlAAAAAMicUAoAAACAzAmlAAAAAMicUAoAAACAzAmlAAAAAMicUAoAAACAzAmlAAAAAMicUAoAAACAzLVu6AKgLkpLS6OsrGyda2bPnp1RNQAAAMD6EkrRZJSWlsaAgYNixfJlDV0KAAAA8CUJpWgyysrKYsXyZVEy6qdRWNK72nXL35wenzxxQ4aVAQAAAHUllKLJKSzpHUXdt6j29pUL5mVYDQAAALA+fNA5AAAAAJkTSgEAAACQOaEUAAAAAJkTSgEAAACQOaEUAAAAAJkTSgEAAACQOaEUAAAAAJkTSgEAAACQOaEUAAAAAJkTSgEAAACQOaEUAAAAAJkTSgEAAACQOaEUAAAAAJkTSgEAAACQOaEUAAAAAJkTSgEAAACQOaEUAAAAAJkTSgEAAACQOaEUAAAAAJkTSgEAAACQOaEUAAAAAJkTSgEAAACQOaEUAAAAAJkTSgEAAACQuTqHUo8//njst99+0bNnzygoKIjJkydXuj2lFBMmTIiePXtGcXFx7LHHHjFr1qx81QsA0OSYnwAAqqpzKLV06dLYfvvt4w9/+MNab7/gggvi4osvjj/84Q/x3HPPRffu3eOb3/xmLF68+EsXCwDQFJmfAACqal3XO4wYMSJGjBix1ttSSnHJJZfEGWecEd/97ncjIuLaa6+Nbt26xU033RTHHHPMl6sWAKAJMj8BAFRV51BqXebOnRvz58+PffbZJ7etqKgohg0bFk899dRah6ry8vIoLy/PXV+0aFE+SwIAaNTWZ36KMEMB0DyVlpZGWVlZjeu6dOkSffr0yaAi6lNeQ6n58+dHRES3bt0qbe/WrVu8/fbba73PpEmTYuLEifksAwCgyVif+SnCDAVA81NaWhoDBg6KFcuX1bi2bXG7mPPKbMFUE5fXUKpCQUFBpesppSrbKowbNy7Gjh2bu75o0aLo3bt3fZQFANBo1WV+ijBDAdD8lJWVxYrly6Jk1E+jsKT6n2krF8yLBfdcFGVlZUKpJi6voVT37t0j4rPf+PXo0SO3/cMPP6zy278KRUVFUVRUlM8yAACajPWZnyLMUAA0X4UlvaOo+xYNXQYZqPPZ99alX79+0b1795g6dWpu26effhrTpk2LIUOG5PNQAADNgvkJAGip6vxOqSVLlsTrr7+euz537tyYOXNmdO7cOfr06RNjxoyJ888/P7bccsvYcsst4/zzz4927drFD3/4w7wWDgDQVJifAACqqnMoNX369Bg+fHjuesVnGRx66KFxzTXXxM9//vNYvnx5HHfccbFw4cLYdddd46GHHooOHTrkr2oAgCbE/AQAUFWdQ6k99tgjUkrV3l5QUBATJkyICRMmfJm6AACaDfMTAEBVef1MKQAAAACoDaEUAAAAAJkTSgEAAACQOaEUAAAAAJkTSgEAAACQOaEUAAAAAJkTSgEAAACQOaEUAAAAAJkTSgEAAACQOaEUAAAAAJkTSgEAAACQOaEUAAAAAJkTSgEAAACQOaEUAAAAAJkTSgEAAACQOaEUAAAAAJkTSgEAAACQOaEUAAAAAJkTSgEAAACQOaEUAAAAAJkTSgEAAACQOaEUAAAAAJkTSgEAAACQudYNXQAAAACQjdLS0igrK1vnmtmzZ2dUzZdTmzq7dOkSffr0qXFdbfpSl/1RO0IpAAAAaAFKS0tjwMBBsWL5soYu5UtZvWRhREFBjB49usa1bYvbxZxXZq8zSKpLX2qzP2pPKAUAAAAtQFlZWaxYvixKRv00Ckt6V7tu+ZvT45MnbsiwsrpZU74kIqUaH8fKBfNiwT0XRVlZ2TpDpNr2pbb7o/aEUgAAANCCFJb0jqLuW1R7+8oF8zKsZv3V9Dgaen/UzAedAwAAAJA5oRQAAAAAmRNKAQAAAJA5oRQAAAAAmRNKAQAAAJA5oRQAAAAAmRNKAQAAAJA5oRQAAAAAmRNKAQAAAJA5oRQAAAAAmRNKAQAAAJA5oRQAAAAAmRNKAQAAAJA5oRQAAAAAmRNKAQAAAJA5oRQAAAAAmRNKAQAAAJA5oRQAAAAAmRNKAQAAAJA5oRQAAAAAmRNKAQAAAJA5oRQAAAAAmRNKAQAAAJA5oRQAAAAAmct7KLVq1ao488wzo1+/flFcXBz9+/ePc845J9asWZPvQwEANAvmJwCgJWqd7x3+6le/issvvzyuvfba2HrrrWP69Olx+OGHR6dOneKkk07K9+EAAJo88xMA0BLlPZR6+umn47//+79j5MiRERGx2Wabxc033xzTp0/P96EAAJoF8xMA0BLl/c/3vva1r8Xf//73ePXVVyMi4sUXX4wnn3wyvvWtb+X7UAAAzYL5CQBoifL+TqlTTz01Pvnkkxg4cGBssMEGsXr16jjvvPPioIMOWuv68vLyKC8vz11ftGhRvksCAGjU6jo/RZihAGg8Zs+eXeOaLl26RJ8+fTKohqYk76HUrbfeGjfccEPcdNNNsfXWW8fMmTNjzJgx0bNnzzj00EOrrJ80aVJMnDgx32UAADQZdZ2fIsxQADS81UsWRhQUxOjRo2tc27a4Xcx5ZbZgikryHkqdcsopcdppp8WBBx4YERHbbrttvP322zFp0qS1DlXjxo2LsWPH5q4vWrQoevfune+yAAAarbrOTxFmKAAa3pryJREpRcmon0ZhSfU/g1YumBcL7rkoysrKhFJUkvdQatmyZdGqVeWPqtpggw2qPaVxUVFRFBUV5bsMAIAmo67zU4QZCoDGo7CkdxR136Khy6AJynsotd9++8V5550Xffr0ia233jpeeOGFuPjii+OII47I96EAAJoF8xMA0BLlPZT6/e9/H2eddVYcd9xx8eGHH0bPnj3jmGOOibPPPjvfhwIAaBbMTwBAS5T3UKpDhw5xySWXxCWXXJLvXQMANEvmJwCgJWpV8xIAAAAAyC+hFAAAAACZE0oBAAAAkDmhFAAAAACZE0oBAAAAkDmhFAAAAACZE0oBAAAAkDmhFAAAAACZE0oBAAAAkDmhFAAAAACZE0oBAAAAkDmhFAAAAACZE0oBAAAAkDmhFAAAAACZE0oBAAAAkDmhFAAAAACZE0oBAAAAkDmhFAAAAACZE0oBAAAAkDmhFAAAAACZE0oBAAAAkDmhFAAAAACZE0oBAAAAkDmhFAAAAACZa93QBUBTMXv27BrXlJeXR1FRUY3runTpEn369MlHWQAAAE1CTa+pavOai+ZFKAU1WL1kYURBQYwePbrmxQWtItKaGpe1LW4Xc16ZLZgCAACavTq9pqJFEUpBDdaUL4lIKUpG/TQKS3pXu275m9PjkyduqHHdygXzYsE9F0VZWZlQCgAAaPbq+pqKlkMoBbVUWNI7irpvUe3tKxfMq9U6AACAlqi2r6loOXzQOQAAAACZE0oBAAAAkDmhFAAAAACZE0oBAAAAkDmhFAAAAACZE0oBAAAAkDmhFAAAAACZE0oBAAAAkDmhFAAAAACZE0oBAAAAkDmhFAAAAACZE0oBAAAAkDmhFAAAAACZE0oBAAAAkDmhFAAAAACZE0oBAAAAkDmhFAAAAACZE0oBAAAAkDmhFAAAAACZE0oBAAAAkDmhFAAAAACZE0oBAAAAkDmhFAAAAACZE0oBAAAAkLl6CaXefffdGD16dJSUlES7du1ihx12iOeff74+DgUA0CyYnwCAlqZ1vne4cOHCGDp0aAwfPjzuv//+6Nq1a7zxxhux0UYb5ftQAADNgvkJAGiJ8h5K/epXv4revXvH1Vdfndu22Wab5fswAADNhvkJAGiJ8h5KTZkyJfbdd9/4/ve/H9OmTYtNN900jjvuuDj66KPXur68vDzKy8tz1xctWpTvkmgCSktLo6ysbJ1rZs+enVE1TU9t+hcR0aVLl+jTp08GFQFQF3WdnyLMUABA05f3UOrNN9+Myy67LMaOHRunn356PPvss3HiiSdGUVFRHHLIIVXWT5o0KSZOnJjvMmhCSktLY8DAQbFi+bKGLqVJqkv/2ha3izmvzBZMATQydZ2fIsxQAEDTl/dQas2aNbHzzjvH+eefHxERO+64Y8yaNSsuu+yytQ5V48aNi7Fjx+auL1q0KHr37p3vsmjEysrKYsXyZVEy6qdRWFL91375m9PjkyduyLCypqG2/Vu5YF4suOeiKCsrE0oBNDJ1nZ8izFAAQNOX91CqR48eMXjw4ErbBg0aFHfcccda1xcVFUVRUVG+y6AJKizpHUXdt6j29pUL5mVYTdNTU/8AaLzqOj9FmKEAgKavVb53OHTo0JgzZ06lba+++mr07ds334cCAGgWzE8AQEuU91Dq5JNPjmeeeSbOP//8eP311+Omm26KK664Io4//vh8HwoAoFkwPwEALVHeQ6mvfvWrcdddd8XNN98c22yzTfziF7+ISy65JH70ox/l+1AAAM2C+QkAaIny/plSERGjRo2KUaNG1ceuAQCaJfMTANDS5P2dUgAAAABQE6EUAAAAAJkTSgEAAACQOaEUAAAAAJkTSgEAAACQOaEUAAAAAJkTSgEAAACQOaEUAAAAAJkTSgEAAACQOaEUAAAAAJkTSgEAAACQOaEUAAAAAJkTSgEAAACQOaEUAAAAAJkTSgEAAACQOaEUAAAAAJkTSgEAAACQOaEUAAAAAJkTSgEAAACQOaEUAAAAAJkTSgEAAACQOaEUAAAAAJkTSgEAAACQudYNXQAAAACwdqWlpVFWVlbjuvLy8igqKlrnmtmzZ+erLMgLoRQAAAA0QqWlpTFg4KBYsXxZzYsLWkWkNfVfFOSRUAoAAAAaobKyslixfFmUjPppFJb0rnbd8jenxydP3FDrddBYCKUAAACgESss6R1F3beo9vaVC+bVaR00Fj7oHAAAAIDMCaUAAAAAyJxQCgAAAIDMCaUAAAAAyJxQCgAAAIDMCaUAAAAAyJxQCgAAAIDMCaUAAAAAyJxQCgAAAIDMCaUAAAAAyJxQCgAAAIDMCaUAAAAAyJxQCgAAAIDMCaUAAAAAyJxQCgAAAIDMCaUAAAAAyJxQCgAAAIDMCaUAAAAAyJxQCgAAAIDMCaUAAAAAyJxQCgAAAIDMCaUAAAAAyJxQCgAAAIDMCaUAAAAAyFy9h1KTJk2KgoKCGDNmTH0fCgCgWTA/AQAtQb2GUs8991xcccUVsd1229XnYQAAmg3zEwDQUtRbKLVkyZL40Y9+FFdeeWVsvPHG9XUYAIBmw/wEALQkretrx8cff3yMHDky9t577zj33HOrXVdeXh7l5eW564sWLaqvkiopLS2NsrKyGtd16dIl+vTpk0FFtDSzZ8+ucU1jf/75PgLIr9rOTxENN0MBkB+1maVr85oBmrJ6CaVuueWWmDFjRjz33HM1rp00aVJMnDixPsqoVmlpaQwYOChWLF9W49q2xe1iziuzvaAmb1YvWRhRUBCjR4+ucW1jfv75PgLIr7rMTxENM0MBkB91maWhOct7KDVv3rw46aST4qGHHoq2bdvWuH7cuHExduzY3PVFixZF7969811WJWVlZbFi+bIoGfXTKCyp/lgrF8yLBfdcFGVlZV5MkzdrypdEpNTkn3++jwDyp67zU0TDzFAA5EdtZ+nlb06PT564IcPKIFt5D6Wef/75+PDDD2OnnXbKbVu9enU8/vjj8Yc//CHKy8tjgw02yN1WVFQURUVF+S6jVgpLekdR9y0a5NjQXJ5/zeVxADSkus5PEQ07QwGQHzXN0isXzMuwGshe3kOpvfbaK1566aVK2w4//PAYOHBgnHrqqVUGKgCAls78BAC0RHkPpTp06BDbbLNNpW3t27ePkpKSKtsBADA/AQAtU6uGLgAAAACAlqdezr73RY899lgWhwEAaDbMTwBAc+edUgAAAABkTigFAAAAQOaEUgAAAABkTigFAAAAQOaEUgAAAABkTigFAAAAQOaEUgAAAABkTigFAAAAQOaEUgAAAABkTigFAAAAQOaEUgAAAABkTigFAAAAQOaEUgAAAABkTigFAAAAQOaEUgAAAABkTigFAAAAQOaEUgAAAABkTigFAAAAQOaEUgAAAABkTigFAAAAQOaEUgAAAABkTigFAAAAQOaEUgAAAABkTigFAAAAQOZaN3QBQONTWloaZWVl61wze/bsOu2zNuu7dOkSffr0qdN+AQCgMamPWZqmpzbPgwivgYRSQCWlpaUxYOCgWLF8WV72t3rJwoiCghg9enSNa9sWt4s5r8xu0f8pAwDQdOV7lqZpqsvzoKW/BhJKAZWUlZXFiuXLomTUT6OwpHe165a/OT0+eeKGGve3pnxJREo17m/lgnmx4J6LoqysrMX+hwwAQNOW71mapqm2zwOvgYRSQDUKS3pHUfctqr195YJ5ed0fAAA0F/mepWmavAaqmQ86BwAAACBzQikAAAAAMieUAgAAACBzQikAAAAAMieUAgAAACBzQikAAAAAMieUAgAAACBzQikAAAAAMieUAgAAACBzQikAAAAAMieUAgAAACBzQikAAAAAMieUAgAAACBzQikAAAAAMieUAgAAACBzQikAAAAAMieUAgAAACBzQikAAAAAMieUAgAAACBzQikAAAAAMieUAgAAACBzQikAAAAAMieUAgAAACBzeQ+lJk2aFF/96lejQ4cO0bVr1/jOd74Tc+bMyfdhAACaDfMTANAS5T2UmjZtWhx//PHxzDPPxNSpU2PVqlWxzz77xNKlS/N9KACAZsH8BAC0RK3zvcMHHnig0vWrr746unbtGs8//3x84xvfyPfhAACaPPMTANAS1ftnSn3yyScREdG5c+f6PhQAQLNgfgIAWoK8v1Pq81JKMXbs2Pja174W22yzzVrXlJeXR3l5ee76okWL6rOkelNaWhplZWU1ruvSpUv06dOnyR+3tmpT3+zZszOqpmmqqT917V++9wdAftVmfopoPjMU0Pw19tcsteW1TdPV2F8D1eb4jf37Y33Vayh1wgknxL/+9a948sknq10zadKkmDhxYn2WUe9KS0tjwMBBsWL5shrXti1uF3NemZ2XJ1NDHbe26lIfVa1esjCioCBGjx7dKPcHQP2ozfwU0TxmKKD5a+yvWWrLa5umqbG/BqpLfY35++PLqLdQ6ic/+UlMmTIlHn/88ejVq1e168aNGxdjx47NXV+0aFH07t27vsqqF2VlZbFi+bIoGfXTKCypvvaVC+bFgnsuirKysrw8kRrquPmub/mb0+OTJ27IrK6mYk35koiU8ta/fO8PgPyr7fwU0TxmKKD5a+yvWWrLa5umqbG/BqptfY39++PLyHsolVKKn/zkJ3HXXXfFY489Fv369Vvn+qKioigqKsp3GQ2isKR3FHXfosUct7Zqqm/lgnkZVtP05Lt/vh4AjU9d56eI5jVDAc1fY3/NUltm6aapsX/dmsv3x/rIeyh1/PHHx0033RR33313dOjQIebPnx8REZ06dYri4uJ8Hw4AoMkzPwEALVHez7532WWXxSeffBJ77LFH9OjRI3e59dZb830oAIBmwfwEALRE9fLnewAA1J75CQBoifL+TikAAAAAqIlQCgAAAIDMCaUAAAAAyJxQCgAAAIDMCaUAAAAAyJxQCgAAAIDMCaUAAAAAyJxQCgAAAIDMCaUAAAAAyJxQCgAAAIDMCaUAAAAAyJxQCgAAAIDMCaUAAAAAyJxQCgAAAIDMCaUAAAAAyJxQCgAAAIDMCaUAAAAAyJxQCgAAAIDMCaUAAAAAyJxQCgAAAIDMCaUAAAAAyJxQCgAAAIDMCaUAAAAAyJxQCgAAAIDMtW7oApqC2bNnf6nb12d9eXl5FBUV5fW4tVFaWhplZWU1ruvSpUv06dMn78eH2jyva/v8a+zPZ/VRFy3t69HSHm9T4msDjU++vy+by/d5c3kcND75zgjyddyI2mUJEY3neS+UWofVSxZGFBTE6NGjs99fQauItCYvx62t0tLSGDBwUKxYvqzGtW2L28WcV2Y3iicxzUNdvj9q8/xr7M9n9VEXLe3r0dIeb1PiawONT76/L5vL93lzeRw0LvnOCOrluLXMEhrL814otQ5rypdEpBQlo34ahSW9q123/M3p8ckTN+R9f/k6bm2VlZXFiuXLajzuygXzYsE9F0VZWVmDP4FpPmr7/VHb519jfz6rj7poaV+PlvZ4mxJfG2h88v192Vy+z5vL46BxyXdGUF/HbUrPe6FULRSW9I6i7ltUe/vKBfPqZX/5Pm5t1XRcqE/5fv419uez+qiLlvb1aGmPtynxtYHGp6XNULXVXB4HjUtjfa1e2yyhMfFB5wAAAABkTigFAAAAQOaEUgAAAABkTigFAAAAQOaEUgAAAABkTigFAAAAQOaEUgAAAABkTigFAAAAQOaEUgAAAABkTigFAAAAQOaEUgAAAABkTigFAAAAQOaEUgAAAABkTigFAAAAQOaEUgAAAABkTigFAAAAQOaEUgAAAABkTigFAAAAQOaEUgAAAABkTigFAAAAQOaEUgAAAABkTigFAAAAQOaEUgAAAABkTigFAAAAQObqLZS69NJLo1+/ftG2bdvYaaed4oknnqivQwEANAvmJwCgJamXUOrWW2+NMWPGxBlnnBEvvPBCfP3rX48RI0ZEaWlpfRwOAKDJMz8BAC1NvYRSF198cRx55JFx1FFHxaBBg+KSSy6J3r17x2WXXVYfhwMAaPLMTwBAS9M63zv89NNP4/nnn4/TTjut0vZ99tknnnrqqSrry8vLo7y8PHf9k08+iYiIRYsW5bu0nCVLlnx27Pmvx5pPV1S7buWCec1j3UfvRETE888/n3vsazNnzpyG2V9j7591jWtdAz2fIyJatWoVa9asWeea2q5Tn3V1WdfSvh51fbxLliyp17mhYt8ppXo7Rl3np4hGPkM1k+eiddY1hXUNNsM38pnMaxvrrGvYGarW81PKs3fffTdFRPrHP/5Raft5552Xttpqqyrrx48fnyLCxcXFxcXFxaVRX+bNm5fvsWm95yczlIuLi4uLi0tTuNQ0P+X9nVIVCgoKKl1PKVXZFhExbty4GDt2bO76mjVr4qOPPoqSkpK1ruezxLF3794xb9686NixY0OX0yToWd3oV93oV93pWd3oV93ls2cppVi8eHH07NkzT9VVr7bzU0TNM5TnTc30qHb0qXb0qXb0qWZ6VDv6VDsN1afazk95D6W6dOkSG2ywQcyfP7/S9g8//DC6detWZX1RUVEUFRVV2rbRRhvlu6xmqWPHjr756kjP6ka/6ka/6k7P6ka/6i5fPevUqVMeqqleXeeniNrPUJ43NdOj2tGn2tGn2tGnmulR7ehT7TREn2ozP+X9g87btGkTO+20U0ydOrXS9qlTp8aQIUPyfTgAgCbP/AQAtET18ud7Y8eOjYMPPjh23nnn2H333eOKK66I0tLSOPbYY+vjcAAATZ75CQBoaeollDrggANiwYIFcc4558T7778f22yzTdx3333Rt2/f+jhci1NUVBTjx4+v8pZ9qqdndaNfdaNfdadndaNfddcUe5bv+akp9iBrelQ7+lQ7+lQ7+lQzPaodfaqdxt6ngpTq8fzGAAAAALAWef9MKQAAAACoiVAKAAAAgMwJpQAAAADInFAKAAAAgMwJpRqpSy+9NPr16xdt27aNnXbaKZ544olq1955553xzW9+MzbZZJPo2LFj7L777vHggw9mWG3Dq0u/nnzyyRg6dGiUlJREcXFxDBw4MH7zm99kWG3jUJeefd4//vGPaN26deywww71W2AjU5d+PfbYY1FQUFDl8sorr2RYccOr63OsvLw8zjjjjOjbt28UFRXF5ptvHldddVVG1Ta8uvTrsMMOW+tzbOutt86w4oZX1+fYjTfeGNtvv320a9cuevToEYcffngsWLAgo2qzMWnSpCgoKIgxY8bktqWUYsKECdGzZ88oLi6OPfbYI2bNmtVwRTaACRMmVPl+6d69e+52PfrMu+++G6NHj46SkpJo165d7LDDDvH888/nbteniM0222yt//8ef/zxEaFHFVatWhVnnnlm9OvXL4qLi6N///5xzjnnxJo1a3Jr9Cpi8eLFMWbMmOjbt28UFxfHkCFD4rnnnsvd3hJ79Pjjj8d+++0XPXv2jIKCgpg8eXKl22vTk/Ly8vjJT34SXbp0ifbt28e3v/3teOeddzJ8FPWvpj7deeedse+++0aXLl2ioKAgZs6cWWUfjaZPiUbnlltuSYWFhenKK69ML7/8cjrppJNS+/bt09tvv73W9SeddFL61a9+lZ599tn06quvpnHjxqXCwsI0Y8aMjCtvGHXt14wZM9JNN92U/v3vf6e5c+em66+/PrVr1y796U9/yrjyhlPXnlX4+OOPU//+/dM+++yTtt9++2yKbQTq2q9HH300RUSaM2dOev/993OXVatWZVx5w1mf59i3v/3ttOuuu6apU6emuXPnpn/+85/pH//4R4ZVN5y69uvjjz+u9NyaN29e6ty5cxo/fny2hTeguvbsiSeeSK1atUq//e1v05tvvpmeeOKJtPXWW6fvfOc7GVdef5599tm02Wabpe222y6ddNJJue2//OUvU4cOHdIdd9yRXnrppXTAAQekHj16pEWLFjVcsRkbP3582nrrrSt933z44Ye52/UopY8++ij17ds3HXbYYemf//xnmjt3bnr44YfT66+/nlujTyl9+OGHlZ5HU6dOTRGRHn300ZSSHlU499xzU0lJSbrnnnvS3Llz02233ZY23HDDdMkll+TW6FVKP/jBD9LgwYPTtGnT0muvvZbGjx+fOnbsmN55552UUsvs0X333ZfOOOOMdMcdd6SISHfddVel22vTk2OPPTZtuummaerUqWnGjBlp+PDhafvtt29Ws3hNfbruuuvSxIkT05VXXpkiIr3wwgtV9tFY+iSUaoR22WWXdOyxx1baNnDgwHTaaafVeh+DBw9OEydOzHdpjVI++vU///M/afTo0fkurdFa354dcMAB6cwzz0zjx49vUaFUXftVEUotXLgwg+oap7r27P7770+dOnVKCxYsyKK8RufL/j921113pYKCgvTWW2/VR3mNUl179utf/zr179+/0rbf/e53qVevXvVWY5YWL16cttxyyzR16tQ0bNiwXCi1Zs2a1L179/TLX/4yt3bFihWpU6dO6fLLL2+garO3rp9bevSZU089NX3ta1+r9nZ9WruTTjopbb755mnNmjV69DkjR45MRxxxRKVt3/3ud3Pztl6ltGzZsrTBBhuke+65p9L27bffPp1xxhl6lFKVsKU2Pfn4449TYWFhuuWWW3Jr3n333dSqVav0wAMPZFZ7ltYWSlWYO3fuWkOpxtQnf77XyHz66afx/PPPxz777FNp+z777BNPPfVUrfaxZs2aWLx4cXTu3Lk+SmxU8tGvF154IZ566qkYNmxYfZTY6Kxvz66++up44403Yvz48fVdYqPyZZ5jO+64Y/To0SP22muvePTRR+uzzEZlfXo2ZcqU2HnnneOCCy6ITTfdNLbaaqv42c9+FsuXL8+i5AaVj//H/vKXv8Tee+8dffv2rY8SG5316dmQIUPinXfeifvuuy9SSvHBBx/E7bffHiNHjsyi5Hp3/PHHx8iRI2PvvfeutH3u3Lkxf/78Sr0qKiqKYcOG1fr51Vy89tpr0bNnz+jXr18ceOCB8eabb0aEHlWo+H/4+9//fnTt2jV23HHHuPLKK3O361NVn376adxwww1xxBFHREFBgR59zte+9rX4+9//Hq+++mpERLz44ovx5JNPxre+9a2I8HyK+OxPHFevXh1t27attL24uDiefPJJPVqL2vTk+eefj5UrV1Za07Nnz9hmm21abN/WpjH1qXWmR6NGZWVlsXr16ujWrVul7d26dYv58+fXah8XXXRRLF26NH7wgx/UR4mNypfpV69eveI///lPrFq1KiZMmBBHHXVUfZbaaKxPz1577bU47bTT4oknnojWrVvWfxvr068ePXrEFVdcETvttFOUl5fH9ddfH3vttVc89thj8Y1vfCOLshvU+vTszTffjCeffDLatm0bd911V5SVlcVxxx0XH330UbP/XKkv+//++++/H/fff3/cdNNN9VVio7M+PRsyZEjceOONccABB8SKFSti1apV8e1vfzt+//vfZ1FyvbrllltixowZlT6HpEJFP9bWq7fffjuT+hqDXXfdNa677rrYaqut4oMPPohzzz03hgwZErNmzdKj/+/NN9+Myy67LMaOHRunn356PPvss3HiiSdGUVFRHHLIIfq0FpMnT46PP/44DjvssIjw/fZ5p556anzyyScxcODA2GCDDWL16tVx3nnnxUEHHRQRehUR0aFDh9h9993jF7/4RQwaNCi6desWN998c/zzn/+MLbfcUo/WojY9mT9/frRp0yY23njjKmtq+3q6JWhMfWpZry6bkIKCgkrXU0pVtq3NzTffHBMmTIi77747unbtWl/lNTrr068nnngilixZEs8880ycdtppscUWW+R+ULYEte3Z6tWr44c//GFMnDgxttpqq6zKa3Tq8hwbMGBADBgwIHd99913j3nz5sWFF17YIkKpCnXp2Zo1a6KgoCBuvPHG6NSpU0REXHzxxbH//vvHH//4xyguLq73ehva+v6/f80118RGG20U3/nOd+qpssarLj17+eWX48QTT4yzzz479t1333j//ffjlFNOiWOPPTb+8pe/ZFFuvZg3b16cdNJJ8dBDD1X5bfvnre/zq7kYMWJE7t/bbrtt7L777rH55pvHtddeG7vttltE6NGaNWti5513jvPPPz8iPnu376xZs+Kyyy6LQw45JLeupffp8/7yl7/EiBEjomfPnpW261HErbfeGjfccEPcdNNNsfXWW8fMmTNjzJgx0bNnzzj00ENz61p6r66//vo44ogjYtNNN40NNtggvvKVr8QPf/jDmDFjRm5NS+/R2qxPT/StdhqiT/58r5Hp0qVLbLDBBlXSyQ8//LBKIvxFt956axx55JHx17/+tcrb95urL9Ovfv36xbbbbhtHH310nHzyyTFhwoR6rLTxqGvPFi9eHNOnT48TTjghWrduHa1bt45zzjknXnzxxWjdunU88sgjWZXeIL7Mc+zzdtttt3jttdfyXV6jtD4969GjR2y66aa5QCoiYtCgQZFSanZnS/miL/McSynFVVddFQcffHC0adOmPstsVNanZ5MmTYqhQ4fGKaecEtttt13su+++cemll8ZVV10V77//fhZl14vnn38+Pvzww9hpp51y/0dPmzYtfve730Xr1q1z/fiy/4c1N+3bt49tt902XnvttdxZ+Fp6j3r06BGDBw+utG3QoEFRWloaEaFPX/D222/Hww8/XOmd9nr0f0455ZQ47bTT4sADD4xtt902Dj744Dj55JNj0qRJEaFXFTbffPOYNm1aLFmyJObNmxfPPvtsrFy5Mvr166dHa1GbnnTv3j0+/fTTWLhwYbVraFx9Eko1Mm3atImddtoppk6dWmn71KlTY8iQIdXe7+abb47DDjssbrrppmbz+Ri1sb79+qKUUpSXl+e7vEaprj3r2LFjvPTSSzFz5szc5dhjj40BAwbEzJkzY9ddd82q9AaRr+fYCy+8ED169Mh3eY3S+vRs6NCh8d5778WSJUty21599dVo1apV9OrVq17rbWhf5jk2bdq0eP311+PII4+szxIbnfXp2bJly6JVq8pjzwYbbBARn/0MaKr22muvKv9H77zzzvGjH/0oZs6cGf3794/u3btX6tWnn34a06ZNq9P/Yc1NeXl5zJ49O3r06JF78dfSezR06NCYM2dOpW2vvvpq7rPq9Kmyq6++Orp27Vpp7taj/1Pd/7lr1qyJCL36ovbt20ePHj1i4cKF8eCDD8Z///d/69Fa1KYnO+20UxQWFlZa8/7778e///3vFtu3tWlUfcr0Y9WplYrTXP/lL39JL7/8chozZkxq37597qxKp512Wjr44INz62+66abUunXr9Mc//rHSKWo//vjjhnoImaprv/7whz+kKVOmpFdffTW9+uqr6aqrrkodO3ZMZ5xxRkM9hMzVtWdf1NLOvlfXfv3mN79Jd911V3r11VfTv//973TaaaeliEh33HFHQz2EzNW1Z4sXL069evVK+++/f5o1a1aaNm1a2nLLLdNRRx3VUA8hU+v7PTl69Oi06667Zl1uo1DXnl199dWpdevW6dJLL01vvPFGevLJJ9POO++cdtlll4Z6CPXm82ffS+mz02d36tQp3Xnnnemll15KBx10ULM/pfgX/fSnP02PPfZYevPNN9MzzzyTRo0alTp06JB7vuhRSs8++2xq3bp1Ou+889Jrr72WbrzxxtSuXbt0ww035Nbo02dWr16d+vTpk0499dQqt+nRZw499NC06aabpnvuuSfNnTs33XnnnalLly7p5z//eW6NXqX0wAMPpPvvvz+9+eab6aGHHkrbb7992mWXXdKnn36aUmqZPVq8eHF64YUX0gsvvJAiIl188cXphRdeSG+//XZKqXY9OfbYY1OvXr3Sww8/nGbMmJH23HPPtP3226dVq1Y11MPKu5r6tGDBgvTCCy+ke++9N0VEuuWWW9ILL7yQ3n///dw+GkufhFKN1B//+MfUt2/f1KZNm/SVr3wlTZs2LXfboYcemoYNG5a7PmzYsBQRVS6HHnpo9oU3kLr063e/+13aeuutU7t27VLHjh3TjjvumC699NK0evXqBqi84dSlZ1/U0kKplOrWr1/96ldp8803T23btk0bb7xx+trXvpbuvffeBqi6YdX1OTZ79uy09957p+Li4tSrV680duzYtGzZsoyrbjh17dfHH3+ciouL0xVXXJFxpY1HXXv2u9/9Lg0ePDgVFxenHj16pB/96EfpnXfeybjq+vfFUGrNmjVp/PjxqXv37qmoqCh94xvfSC+99FLDFdgADjjggNSjR49UWFiYevbsmb773e+mWbNm5W7Xo8/87W9/S9tss00qKipKAwcOrPL/iz595sEHH0wRkebMmVPlNj36zKJFi9JJJ52U+vTpk9q2bZv69++fzjjjjFReXp5bo1cp3Xrrral///6pTZs2qXv37un444+v9MaCltijRx99dJ2vbWvTk+XLl6cTTjghde7cORUXF6dRo0al0tLSBng09aemPl199dVrvX38+PG5fTSWPhWk1ITfsw4AAABAk+QzpQAAAADInFAKAAAAgMwJpQAAAADInFAKAAAAgMwJpQAAAADInFAKAAAAgMwJpQAAAADInFAKAAAAgMwJpQAAAADInFAKAAAAgMwJpQAAAADInFAKAAAAgMz9Px36ZQPpXpNpAAAAAElFTkSuQmCC",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABKUAAAHqCAYAAADVi/1VAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjAsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvlHJYcgAAAAlwSFlzAAAPYQAAD2EBqD+naQAAWClJREFUeJzt3XlcVGX///H3oDiA4gYiooBL5Z6a5lqhWXqTtNxl2aK5lN9MK5U2aVOspP22u9KyUiszrUzztrS0XDPLtUVJMxfIpYJUxGVUuH5/9GNyAgR05hrA1/PxmMfDc+aacz7nmgvm8s2ZcxzGGCMAAAAAAADAogB/FwAAAAAAAICzD6EUAAAAAAAArCOUAgAAAAAAgHWEUgAAAAAAALCOUAoAAAAAAADWEUoBAAAAAADAOkIpAAAAAAAAWEcoBQAAAAAAAOsIpQAAAAAAAGAdoRQAAAAAD1OnTpXD4XA/KlasqDp16ujGG2/Uzz//7O/yfGLTpk0aM2aMduzYUaz2K1eu1JgxY7R///58z9WvX18JCQneLdCirl27qkWLFn7Z9+HDhzVmzBgtWbKkRK9bvny5nE6ndu7c6V43YcIETZ069bRr2bFjhxwOh5577rnT3oav5eTkKCIiQv/5z3+K1X7fvn2qXr265syZ49vCgGIilAL87OQJ36keS5Ys0YABA1S/fn1/l+y2e/dujRkzRhs2bPD6ttevX6+4uDhVq1ZNDodD48eP15IlS9x94S3jxo0r9ofy6U6STpY3yV+zZs1pb8PbCprEFYUJDQCcHaZMmaKvv/5aixYt0l133aW5c+fqoosu0r59+/xdmtdt2rRJycnJJQqlkpOTCwylcPoOHz6s5OTkEs23jDEaMWKEBg8erNjYWPf6Mw2lyoJly5bpjz/+0LXXXlus9jVq1NDIkSN1//3369ixYz6uDihaRX8XAJztvv76a4/lxx9/XIsXL9aXX37psb5Zs2aKjo7W8OHDbZZ3Srt371ZycrLq16+v1q1be3XbgwYN0qFDhzRjxgzVqFFD9evXV0hIiL7++ms1a9bMa/sZN26cevfurWuuuabItnmTJOmvvyCWB4VN4opy8oTmiiuuUKVKlXxYJQDAX1q0aKF27dpJ+uuzLycnR6NHj9acOXM0cOBAP1dXPh05ckRBQUFyOBz+LqXMWLBggdatW6fp06f7uxTrPvzwQ7Vr165E87ghQ4boiSee0Icffqibb77Zh9UBReNMKcDPOnbs6PGoVauWAgIC8q2vWrWqGjVqpDZt2vi7ZCt+/PFHXXbZZYqPj1fHjh0VGRmpqlWruvviVA4fPmypyrIvbxJ39913l/i1Q4YM0Y4dO/Thhx/6oDIAQGmUF1D99ttvHuvXrFmjq666SjVr1lRQUJDatGmj999/P9/rV61apS5duigoKEhRUVFKSkrS66+/LofD4XGGksPh0JgxY/K9vn79+howYIDHur179+qOO+5QvXr1VKlSJTVo0EDJyck6ceKER7uJEyeqVatWqlKlikJDQ9WkSRM99NBDkv46k/n666+XJHXr1s19pnphZ9mMGTNG999/vySpQYMGHme2n2zBggW64IILFBwcrCZNmmjy5Mkez+edQf35559r0KBBqlWrlkJCQuRyuZSbm6tnnnlGTZo0kdPpVEREhG699Vb9+uuvRfaJ9FeI+M8/om3cuFE9evRQSEiIatWqpWHDhumTTz4p9Ez01atX6+KLL1ZISIgaNmyop556Srm5ue7n885inzZtmhITExUZGang4GDFxcVp/fr1RdYjyeObADt27FCtWrUkScnJye5+Lej4TjZx4kRdeOGFaty4sUe/bNy4UUuXLnVv5+RvHKSlpalv376KiIiQ0+lU06ZN9fzzz3scX0GOHz+u/v37q0qVKpo3b56kv/7IN2HCBLVu3VrBwcGqUaOGevfurW3btuXrgxYtWhTZr7m5uXriiSfUuHFjBQcHq3r16jr//PP14osvemzPGKPZs2fruuuuc6/78ssv1bVrV4WFhSk4OFgxMTG67rrrPObHtWvX1uWXX65XX331lMcK2EAoBZQhBX19z+Fw6K677tKUKVPcH1zt2rXTqlWrZIzRs88+qwYNGqhKlSq69NJLtXXr1nzbXbRokbp3766qVasqJCREXbp00RdffHHKWpYsWaILL7xQkjRw4ED3h/3JE8i5c+eqU6dOCgkJUWhoqC6//PJ8Z4b9U97k7MSJE5o4caJ7u3n7/OekacCAAapSpYp++OEH9ejRQ6Ghoerevbukv74CmJCQ4J5sREVFqVevXu7JnMPh0KFDh/TWW2+591PYGVDFmSStWLFC3bt3V2hoqEJCQtS5c2d98sknpzxeSdqzZ4/atm2rc889132djqysLN13331q0KCBKlWqpLp162rEiBE6dOiQx2vz3v933nlHTZs2VUhIiFq1auWeJBWloEmcxIQGAFCw7du3S5LOO+8897rFixerS5cu2r9/v1599VV9/PHHat26tfr06eMR6mzatEndu3fX/v37NXXqVL366qtav369nnjiidOuZ+/evWrfvr0+++wzPfbYY5o/f75uu+02paSkaPDgwe52M2bM0NChQxUXF6fZs2drzpw5GjlypPtztVevXho3bpwk6ZVXXtHXX3+tr7/+Wr169Spwv7fffrv7DzofffSRu/0FF1zgbvPdd9/p3nvv1ciRI/Xxxx/r/PPP12233aZly5bl296gQYMUGBiod955Rx9++KECAwN155136sEHH9Tll1+uuXPn6vHHH9eCBQvUuXNnZWRklLiv9uzZo7i4OG3evFkTJ07U22+/rYMHD+quu+4qtG9vueUW9e3bV3PnzlV8fLySkpI0bdq0fG0feughbdu2TW+88YbeeOMN7d69W127ds0XyhSlTp06WrBggSTptttuc/fro48+Wuhrjh07pkWLFqlbt24e62fPnq2GDRuqTZs27u3Mnj1bkvTHH3+oc+fO+vzzz/X4449r7ty5uuyyy3TfffcV2h+StH//fvXs2VOff/65li5d6r5u2B133KERI0bosssu05w5czRhwgRt3LhRnTt3zhfgFqdfn3nmGY0ZM0Y33XSTPvnkE82cOVO33XZbvq+Krly5Unv27HGHUjt27FCvXr1UqVIlTZ48WQsWLNBTTz2lypUr5/uqXteuXfXVV1/x9VP4nwFQqvTv399Urly50OdiY2M91kkysbGxpnPnzuajjz4ys2fPNuedd56pWbOmGTlypLn66qvNvHnzzLvvvmtq165tzj//fJObm+t+/TvvvGMcDoe55pprzEcffWT+97//mYSEBFOhQgWzaNGiQus8cOCAmTJlipFkHnnkEfP111+br7/+2qSnpxtjjHn33XeNJNOjRw8zZ84cM3PmTNO2bVtTqVIls3z58kK3+/vvv5uvv/7aSDK9e/d2b9cYYxYvXmwkmcWLF3v0SWBgoKlfv75JSUkxX3zxhfnss89Mdna2CQsLM+3atTPvv/++Wbp0qZk5c6YZMmSI2bRpkzHGmK+//toEBwebK664wr2fjRs3FljX0aNHzYIFC4wkc9ttt7nbb9261RhjzJIlS0xgYKBp27atmTlzppkzZ47p0aOHcTgcZsaMGe7t5PXZ6tWrjTHG/PDDDyY6Otp06tTJ/PHHH8YYYw4dOmRat25twsPDzQsvvGAWLVpkXnzxRVOtWjVz6aWXerx/kkz9+vVN+/btzfvvv28+/fRT07VrV1OxYkXzyy+/FNrPxhjjcrlMcHCweeCBBzzWb9++3QQFBZnLL7/czJkzxyxZssS8++67pl+/fmbfvn0ebZ9++mkTEBCQbz0AoGzL+7xatWqVOX78uDl48KBZsGCBiYyMNJdccok5fvy4u22TJk1MmzZtPNYZY0xCQoKpU6eOycnJMcYY06dPHxMcHGz27t3rbnPixAnTpEkTI8ls377dvV6SGT16dL66YmNjTf/+/d3Ld9xxh6lSpYrZuXOnR7vnnnvOSHJ/rt91112mevXqpzzmDz74IN8841SeffbZfHWfXGdQUJBHXUeOHDE1a9Y0d9xxh3tdXj/feuutHq9PTU01kszQoUM91n/zzTdGknnooYc89nVyn+SJi4szcXFx7uX777/fOByOfHOdnj175jvuuLg4I8l88803Hm2bNWtmevbs6V7Om5tdcMEFHvOTHTt2mMDAQHP77bcXWk+ef85v//jjj0Lf/4Lk9cnJ8608zZs3L3Cfo0aNKvD47rzzTuNwOMzmzZuNMX/NiSSZZ5991mzfvt00a9bMNGvWzOzYscP9mrx56/PPP++xrfT09HzzrOL2a0JCgmndunWRxz5ixAjTsmVL9/KHH35oJJkNGzYU+dqFCxcaSWb+/PlFtgV8iVAKKGVOJ5SKjIw02dnZ7nVz5swxkkzr1q09Jgjjx483ksz3339vjPkr/KhZs6a58sorPbaZk5NjWrVqZdq3b3/KWlevXm0kmSlTpuR7fVRUlGnZsqV7ImqMMQcPHjQRERGmc+fOp9xu3nENGzbMY11hoZQkM3nyZI+2a9asMZLMnDlzTrmfypUrFziRK8ipJkkdO3Y0ERER5uDBg+51J06cMC1atDD16tVzvw8nh1ILFy40VatWNb179zZHjhxxvy4lJcUEBAS4g6s8eRONTz/91L1Okqldu7bJyspyr9u7d68JCAgwKSkppzyewiZxTGgAAHmfV/98NG3a1OMPET///LORZJ577jlz/Phxj8eECROMJPcfgyIiIkxCQkK+fY0ePfq0Q6m6deuaK6+8Mt++N27caCSZCRMmGGOMefvtt40kc+ONN5o5c+a4/xB0Mm+HUh07dsy3vmPHjuZf//qXezmvnz/++GOPdnl99+233+bbRtOmTU2HDh089lWcUKp9+/YeAUaeqVOnFhhKRUZG5mt74403miZNmriX8+Zmzz33XIH7b9SoUaH15DnTUGr27NlGkvnyyy/zPVdYKNW+fXvTrFmzfOvz5kYTJ040xvwdSt10002mdu3aplu3bvn+EPfwww8bh8Nhfvvtt3zjsGPHjh7z6eL269ixY43D4TB33nmnWbBggTlw4ECBxx4TE2PGjBnjXt66daupVKmSad++vZk6deop/0D53XffGUnmjTfeKLQNYANf3wPKgW7duqly5cru5aZNm0qS4uPjPS6Smbc+7y5rK1eu1J9//qn+/fvrxIkT7kdubq7+9a9/afXq1fm+LlYcmzdv1u7du9WvXz8FBPz9a6ZKlSq67rrrtGrVKq9f9+nk79JL0jnnnKMaNWrowQcf1KuvvqpNmzZ5dX8nO3TokL755hv17t1bVapUca+vUKGC+vXrp19//VWbN2/2eM1bb72lK664Qrfffrvef/99BQUFuZ+bN2+eWrRoodatW3u8Lz179izwmg/dunVTaGioe7l27dqKiIgo8m56u3fvliRFRER4rG/durUqVaqk//u//9Nbb711ylPv8167a9euU+4LAFA2vf3221q9erW+/PJL3XHHHUpNTdVNN93kfj7vq0n33XefAgMDPR5Dhw6VJPdXzTIzMxUZGZlvHwWtK67ffvtN//vf//Ltu3nz5h777tevnyZPnqydO3fquuuuU0REhDp06KCFCxee9r6LEhYWlm+d0+nUkSNH8q2vU6eOx3JmZmaB6yUpKirK/XxJZGZmqnbt2vnWF7ROKln9hb2vp1NnSeXVc/JcqiiZmZmF9m3e8ydbuHChfvvtN91+++2qXr26x3O//fabjDGqXbt2vnG4atWqfF+1LE6/JiUl6bnnntOqVasUHx+vsLAwde/e3ePuzd9++63S0tI85sCNGjXSokWLFBERoWHDhqlRo0Zq1KhRvmtRSX/3V0HvJ2ATd98DyoGaNWt6LOfdCa2w9UePHpX090Syd+/ehW77zz//9Ai8iqOoiVRubq727dunkJCQEm23MCEhIfkufl6tWjUtXbpUTz75pB566CHt27dPderU0eDBg/XII48oMDDQK/uWpH379skYU6LJzYwZMxQcHKzbb7893911fvvtN23durXQGk9nclOQwiZxeROaZ555RsOGDdOhQ4fUsGFD3XPPPfnu/siEBgDKt6ZNm7ovbt6tWzfl5OTojTfe0IcffqjevXsrPDxc0l//iS7slvR51y0MCwvT3r178z1f0Dqn0ymXy5Vv/T8/T8PDw3X++efrySefLHDfeZ/D0l/XwBw4cKAOHTqkZcuWafTo0UpISNCWLVtKdOcyX/jnXCDvs33Pnj2qV6+ex3O7d+9297v012dxQX2VkZHh0S4sLCzf9Y2kgvu/pAp7X0+eowQFBenAgQMF1nkm8o7xzz//LPZrwsLCtGfPnnzr8/5gd3K/SdL999+vX375RbfeeqtOnDihW2+91WP/DodDy5cvl9PpzLfNgtYVpWLFikpMTFRiYqL279+vRYsW6aGHHlLPnj2Vnp6ukJAQzZo1S+edd55atGjh8dqLL75YF198sXJycrRmzRq99NJLGjFihGrXrq0bb7zR3S6vv/55rIBthFLAWSzvQ+ill15Sx44dC2xT2F/PTuXkidQ/7d69WwEBAapRo0aJt1uYwm6Z3LJlS82YMUPGGH3//feaOnWqxo4dq+DgYI0aNcpr+69Ro4YCAgJKNLl599139eijjyouLk6ff/65Wrdu7X4uPDxcwcHB+e7Qc/Lz3nCqSRwTGgBAQZ555hnNmjVLjz32mK699lo1btxY5557rr777jv3hcIL061bN82dO1e//fabe36Rk5OjmTNn5mtbv359ff/99x7rvvzyS2VnZ3usS0hI0KeffqpGjRoVe25RuXJlxcfH69ixY7rmmmu0ceNGxcbGusOD4v6hpaTtS+LSSy+VJE2bNs19Yxnpr7vhpaam6uGHH3avK6ivtmzZos2bN3t8PsfFxem5557Tpk2b1KxZM/f6GTNmnHG97733nhITE91zsp07d2rlypUe4U39+vX1wQcfyOVyufsuMzNTK1eu9PjjYkn7Ne+bAL/88ku+5wr7I1337t2VkpKidevWeVyc/u2335bD4ch30fSAgAC99tprqlKligYMGKBDhw7pzjvvlPTXGHzqqae0a9cu3XDDDcWquSSqV6+u3r17a9euXRoxYoR27NihZs2aadasWafcX4UKFdShQwc1adJE7777rtatW+cxh8s7E/7ksQD4A6EUcBbr0qWLqlevrk2bNp3yTiOFKWzS0LhxY9WtW1fTp0/Xfffd556gHDp0SLNmzXLfkc8Wh8OhVq1a6T//+Y+mTp2qdevWeRzDmU4+K1eurA4dOuijjz7Sc889p+DgYEl/3c532rRpqlevnsddiqS/zmJbtGiREhIS1K1bN82fP98dDCYkJGjcuHEKCwtTgwYNTvu4i3KqSVweJjQAgJPVqFFDSUlJeuCBBzR9+nT17dtXr732muLj49WzZ08NGDBAdevW1Z9//qnU1FStW7dOH3zwgSTpkUce0dy5c3XppZfqscceU0hIiF555ZUCLxXQr18/Pfroo3rssccUFxenTZs26eWXX1a1atU82o0dO1YLFy5U586ddc8996hx48Y6evSoduzYoU8//VSvvvqq6tWrp8GDBys4OFhdunRRnTp1tHfvXqWkpKhatWru0CfvjJNJkyYpNDRUQUFBatCgQYFnJEt//fFLkl588UX1799fgYGBaty4scdX6k9X48aN9X//93966aWXFBAQoPj4eO3YsUOPPvqooqOjNXLkSI++6tu3r4YOHarrrrtOO3fu1DPPPOO+a3CeESNGaPLkyYqPj9fYsWNVu3ZtTZ8+XT/99JMkeVxyoaR+//13/fvf/9bgwYN14MABjR49WkFBQUpKSvKo87XXXlPfvn01ePBgZWZm6plnnsl3tntoaKhiY2P18ccfq3v37qpZs6bCw8Pz3YE6T7169dSwYUOtWrVK99xzj8dzeX+gnDlzpho2bKigoCC1bNlSI0eO1Ntvv61evXpp7Nixio2N1SeffKIJEybozjvvzDdvy/P8888rNDRUQ4cOVXZ2tu6//3516dJF//d//6eBAwdqzZo1uuSSS1S5cmXt2bNHK1asUMuWLd0BVnFdeeWVatGihdq1a6datWpp586dGj9+vGJjY3Xuuedqw4YN+uWXX/JdvuLVV1/Vl19+qV69eikmJkZHjx51/5Hzsssu82i7atUqhYWFuccx4Dd+vqYVgH84nQud//OC4CffKeRkeRej/OCDD9zr3nnnHRMQEGD69OljPvjgA7N06VLz4YcfmkcffdQMGTLklLUeOnTIBAcHmy5dupjFixeb1atXm127dhlj/r773hVXXGE+/vhj8/7775sLL7ywyLvvneq4CrvQeUH99b///c/Ex8eb1157zSxcuNB8/vnnZsiQIUaSmTRpkrtdXFyciYiIMHPnzjWrV682P/300ynrio2NNY0bNzafffaZWb16tfvipnl33+vQoYP54IMPzMcff2x69uxZ5N33Dh8+bP71r3+ZKlWquC/QmZ2dbdq0aWPq1atnnn/+ebNw4ULz2Wefmddff91cf/31ZtWqVafsp7w6i3MB94YNG5qbbrrJY93EiRPN9ddfb6ZOnWq+/PJL8+mnn5revXsbSeazzz7zaHv33XebsLAwjwvqAwDKvn9+Xp3syJEjJiYmxpx77rnmxIkTxpi/Lpp8ww03mIiICBMYGGgiIyPNpZdeal599VWP13711VemY8eOxul0msjISHP//febSZMm5btguMvlMg888ICJjo42wcHBJi4uzmzYsKHAz7c//vjD3HPPPaZBgwYmMDDQ1KxZ07Rt29Y8/PDD7hvBvPXWW6Zbt26mdu3aplKlSiYqKsrccMMN7pu/5Bk/frxp0KCBqVChQoE3c/mnpKQkExUVZQICAjzmKLGxsaZXr1752v/zYt+n6uecnBzz9NNPm/POO88EBgaa8PBw07dvX/edjvPk5uaaZ555xjRs2NAEBQWZdu3amS+//LLAC4v/+OOP5rLLLjNBQUGmZs2a5rbbbjNvvfWWkWS+++47jzqbN2+er6Z/zkXz5mbvvPOOueeee0ytWrWM0+k0F198sVmzZk2+17/11lumadOmJigoyDRr1szMnDmzwPntokWLTJs2bYzT6TSSipzTPProo6ZGjRrm6NGjHut37NhhevToYUJDQ913rM6zc+dOc/PNN5uwsDATGBhoGjdubJ599lmPm/QUNqfOu8j9Y4895l43efJk06FDB1O5cmUTHBxsGjVqZG699VaPfihuvz7//POmc+fOJjw83FSqVMnExMSY2267zX3Xv0ceeSRfnxnz150A//3vf5vY2FjjdDpNWFiYiYuLM3PnzvVol5uba2JjY83dd99deKcClhBKAaWM7VDKGGOWLl1qevXqZWrWrGkCAwNN3bp1Ta9evfK1K8h7771nmjRpYgIDA/PdKWXOnDmmQ4cOJigoyFSuXNl0797dfPXVV0Vus7DjKkko9dNPP5mbbrrJNGrUyAQHB5tq1aq570Rysg0bNpguXbqYkJAQI6nAO7Sc7FSTpOXLl5tLL73UPRnp2LGj+d///ufx+oImny6Xy1x33XUmKCjIfPLJJ8aYv4KpRx55xDRu3NhUqlTJVKtWzbRs2dKMHDnS41baZxpKFTSJY0IDALAp77OxoLvYwfcGDx5sqlSpYlwuV4lfW9jc0rZdu3aZSpUq5bujcHnVtGlTk5iYeNqvX7RokQkICDCpqalerAo4PQ5jjPH56VgAgFJp9+7datCggd5++2316dOnRK/94osv1KNHD23cuFFNmjTxUYUAgPJu6tSpGjhwoLZv317oV7TgHWPHjlVUVJQaNmyo7OxszZs3T2+88YYeeeQRjR07tsTbW7Jkibp166YPPvjglDfOseHBBx/U/PnztWHDhjP6KuLZoFu3bjrnnHP0+uuv+7sUgGtKAcDZLCoqSiNGjNCTTz6p66+/vkSTuCeeeEKDBg0ikAIAoIwIDAzUs88+q19//VUnTpzQueeeqxdeeCHf3XXLokceeUQhISHatWuXoqOj/V1OqbVv3z7FxcVp6NCh/i4FkCRxphQAnOUOHjyoF154QYMGDSr2JG7fvn168cUXNXToUEVERPi4QgAAAADlEaEUAAAAAAAArOPLtgAAAAAAALCOUAoAAAAAAADWlboLnefm5mr37t0KDQ2Vw+HwdzkAAAAejDE6ePCgoqKi/HqHJ+ZMAACgtCrufKnUhVK7d+/mbgkAAKDUS09PV7169fy2f+ZMAACgtCtqvlTqQqnQ0FBJfxVetWpVP1cDAADgKSsrS9HR0e45i78wZwIAAKVVcedLpS6Uyjv9vGrVqkywAABAqeXvr8wxZwIAAKVdUfMlLnQOAAAAAAAA6wilAAAAAAAAYB2hFAAAAAAAAKwjlAIAAAAAAIB1hFIAAAAAAACwjlAKAAAAAAAA1hFKAQAAAAAAwDpCKQAAAAAAAFhHKAUAAAAAAADrCKUAAAAAAABgHaEUAAAAAAAArCOUAgAAAAAAgHWEUgAAAAAAALCOUAoAAMCy+vXry+Fw5HsMGzbM36UBAABYU9HfBQAAAJxtVq9erZycHPfyjz/+qMsvv1zXX3+9H6sCAACwi1AKAADAslq1anksP/XUU2rUqJHi4uL8VBEAAIB9fH0PAADAj44dO6Zp06Zp0KBBcjgc/i4HAADAGs6UQrmWlpamjIyMItuFh4crJibGQkUAAHiaM2eO9u/frwEDBpyyncvlksvlci9nZWX5uDIAgMT/KQBfIpRCuZWWlqbGTZrq6JHDRbYNCg7R5p9S+RABAFj35ptvKj4+XlFRUadsl5KSouTkZEtVAQAk/k8B+BqhFMqtjIwMHT1yWGEJ9yowLLrQdscz05U573llZGTwAQIAsGrnzp1atGiRPvrooyLbJiUlKTEx0b2clZWl6OjCP98AAGeO/1MAvkUohXIvMCxazshz/F0GAAD5TJkyRREREerVq1eRbZ1Op5xOp4WqAAD/xP8pAN/gQucAAAB+kJubqylTpqh///6qWJG/EwIAgLMPoRQAAIAfLFq0SGlpaRo0aJC/SwEAAPAL/iwHAADgBz169JAxxt9lAAAA+A1nSgEAAAAAAMA6QikAAAAAAABYRygFAAAAAAAA6wilAAAAAAAAYB2hFAAAAAAAAKwjlAIAAAAAAIB1hFIAAAAAAACwjlAKAAAAAAAA1hFKAQAAAAAAwDpCKQAAAAAAAFhHKAUAAAAAAADrCKUAAAAAAABgHaEUAAAAAAAArCOUAgAAAAAAgHWEUgAAAAAAALCOUAoAAAAAAADWEUoBAAAAAADAOkIpAAAAAAAAWEcoBQAAAAAAAOsIpQAAAAAAAGBdiUOpZcuW6corr1RUVJQcDofmzJnjfu748eN68MEH1bJlS1WuXFlRUVG69dZbtXv3bm/WDAAAAAAAgDKuxKHUoUOH1KpVK7388sv5njt8+LDWrVunRx99VOvWrdNHH32kLVu26KqrrvJKsQAAAAAAACgfKpb0BfHx8YqPjy/wuWrVqmnhwoUe61566SW1b99eaWlpiomJOb0qAQAAAAAAUK74/JpSBw4ckMPhUPXq1X29KwAAAAAAAJQRJT5TqiSOHj2qUaNG6eabb1bVqlULbONyueRyudzLWVlZviwJAAAAAAAApYDPzpQ6fvy4brzxRuXm5mrChAmFtktJSVG1atXcj+joaF+VBAAAAAAAgFLCJ6HU8ePHdcMNN2j79u1auHBhoWdJSVJSUpIOHDjgfqSnp/uiJAAAAAAAAJQiXv/6Xl4g9fPPP2vx4sUKCws7ZXun0ymn0+ntMgAAAAAAAFCKlTiUys7O1tatW93L27dv14YNG1SzZk1FRUWpd+/eWrdunebNm6ecnBzt3btXklSzZk1VqlTJe5UDAAAAAACgzCpxKLVmzRp169bNvZyYmChJ6t+/v8aMGaO5c+dKklq3bu3xusWLF6tr166nXykAAAAAAADKjRKHUl27dpUxptDnT/UcAAAAAAAAIPnw7nsAAAAAAABAYQilAAAAAAAAYB2hFAAAAAAAAKwjlAIAAAAAAIB1hFIAAAAAAACwjlAKAAAAAAAA1hFKAQAAAAAAwDpCKQAAAAAAAFhHKAUAAAAAAADrCKUAAAAAAABgHaEUAAAAAAAArCOUAgAAAAAAgHWEUgAAAAAAALCOUAoAAAAAAADWEUoBAAAAAADAOkIpAAAAAAAAWEcoBQAA4Ae7du1S3759FRYWppCQELVu3Vpr1671d1kAAADWVPR3AQAAAGebffv2qUuXLurWrZvmz5+viIgI/fLLL6pevbq/SwMAALCGUAoAAMCyp59+WtHR0ZoyZYp7Xf369f1XEAAAgB/w9T0AAADL5s6dq3bt2un6669XRESE2rRpo9dff93fZQEAAFjFmVIAAACWbdu2TRMnTlRiYqIeeughffvtt7rnnnvkdDp16623Fvgal8sll8vlXs7KyrJVLgD4VFpamjIyMopsFx4erpiYGAsVnb7U1NQi27hcLjmdzmJtrywcc2lWnsZWeUUoBQAAYFlubq7atWuncePGSZLatGmjjRs3auLEiYWGUikpKUpOTrZZJgD4XFpamho3aaqjRw4X2TYoOESbf0otleFBTvY+yeFQ3759i27sCJBMbrG2W5qPubQrL2OrvCOUAgAAsKxOnTpq1qyZx7qmTZtq1qxZhb4mKSlJiYmJ7uWsrCxFR0f7rEYAsCEjI0NHjxxWWMK9Cgwr/Hfa8cx0Zc57XhkZGaUyOMh1ZUvGFHkcR7at0YHl04psJ5X+Yy7tysvYKu8IpQAAACzr0qWLNm/e7LFuy5Ytio2NLfQ1Tqez2F/3AICyJjAsWs7Ic/xdxhkr6jiOZ6YXqx28h74u3QilAB/gu8sAgFMZOXKkOnfurHHjxumGG27Qt99+q0mTJmnSpEn+Lg0AAMAaQinAy/juMgCgKBdeeKFmz56tpKQkjR07Vg0aNND48eN1yy23+Ls0AAAAawilAC/ju8sAgOJISEhQQkKCv8sAAADwG0IpwEf47jIAAAAAAIUL8HcBAAAAAAAAOPsQSgEAAAAAAMA6QikAAAAAAABYRygFAAAAAAAA6wilAAAAAAAAYB2hFAAAAAAAAKwjlAIAAAAAAIB1hFIAAAAAAACwjlAKAAAAAAAA1hFKAQAAAAAAwDpCKQAAAAAAAFhHKAUAAAAAAADrCKUAAAAAAABgHaEUAAAAAAAArCOUAgAAAAAAgHWEUgAAAAAAALCOUAoAAAAAAADWEUoBAAAAAADAOkIpAAAAAAAAWEcoBQAAAAAAAOsIpQAAAAAAAGAdoRQAAAAAAACsI5QCAAAAAACAdYRSAAAAAAAAsK7EodSyZct05ZVXKioqSg6HQ3PmzPF43hijMWPGKCoqSsHBweratas2btzorXoBAAAAAABQDpQ4lDp06JBatWqll19+ucDnn3nmGb3wwgt6+eWXtXr1akVGRuryyy/XwYMHz7hYAAAAAAAAlA8VS/qC+Ph4xcfHF/icMUbjx4/Xww8/rGuvvVaS9NZbb6l27dqaPn267rjjjjOrFgAAAAAAAOVCiUOpU9m+fbv27t2rHj16uNc5nU7FxcVp5cqVBYZSLpdLLpfLvZyVleXNkgCvSktLU0ZGxinbpKamWqoGAAAAAICyy6uh1N69eyVJtWvX9lhfu3Zt7dy5s8DXpKSkKDk52ZtlAD6Rlpamxk2a6uiRw/4uBQAAAACAMs+roVQeh8PhsWyMybcuT1JSkhITE93LWVlZio6O9kVZwBnJyMjQ0SOHFZZwrwLDCh+jR7at0YHl0yxWBgAAAABA2ePVUCoyMlLSX2dM1alTx73+999/z3f2VB6n0ymn0+nNMgCfCgyLljPynEKfP56ZbrEaAAAAAADKphLffe9UGjRooMjISC1cuNC97tixY1q6dKk6d+7szV0BAAAAAACgDCvxmVLZ2dnaunWre3n79u3asGGDatasqZiYGI0YMULjxo3Tueeeq3PPPVfjxo1TSEiIbr75Zq8WDgAAAAAAgLKrxKHUmjVr1K1bN/dy3vWg+vfvr6lTp+qBBx7QkSNHNHToUO3bt08dOnTQ559/rtDQUO9VDQAAAAAAgDKtxKFU165dZYwp9HmHw6ExY8ZozJgxZ1IXAAAAAAAAyjGvXlMKAAAAAAAAKA5CKQAAAAAAAFhHKAUAAAAAAADrCKUAAAAAAABgHaEUAAAAAAAArCOUAgAAAAAAgHWEUgAAAAAAALCOUAoAAAAAAADWEUoBAAAAAADAOkIpAAAAAAAAWEcoBQAAAAAAAOsIpQAAACwbM2aMHA6HxyMyMtLfZQEAAFhV0d8FAAAAnI2aN2+uRYsWuZcrVKjgx2oAAADsI5QCAADwg4oVK3J2FAAAOKvx9T0AAAA/+PnnnxUVFaUGDRroxhtv1LZt2/xdEgAAgFWcKQUAAGBZhw4d9Pbbb+u8887Tb7/9pieeeEKdO3fWxo0bFRYWVuBrXC6XXC6XezkrK8tWuQCAs0xaWpoyMjKKbBceHq6YmBgLFaG8IpQCAACwLD4+3v3vli1bqlOnTmrUqJHeeustJSYmFvialJQUJScn2yoRAHCWSktLU+MmTXX0yOEi2wYFh2jzT6kEUzhthFIAAAB+VrlyZbVs2VI///xzoW2SkpI8AqusrCxFR0fbKA8AcBbJyMjQ0SOHFZZwrwLDCv+cOZ6Zrsx5zysjI4NQCqeNUAoAAMDPXC6XUlNTdfHFFxfaxul0yul0WqwKAHA2CwyLljPyHH+XgXKOC50DAABYdt9992np0qXavn27vvnmG/Xu3VtZWVnq37+/v0sDAACwhjOlAAAALPv111910003KSMjQ7Vq1VLHjh21atUqxcbG+rs0AAAAawilAAAALJsxY4a/SwAAAPA7vr4HAAAAAAAA6wilAAAAAAAAYB2hFAAAAAAAAKwjlAIAAAAAAIB1hFIAAAAAAACwjlAKAAAAAAAA1hFKAQAAAAAAwDpCKQAAAAAAAFhHKAUAAAAAAADrCKUAAAAAAABgHaEUAAAAAAAArCOUAgAAAAAAgHWEUgAAAAAAALCOUAoAAAAAAADWEUoBAAAAAADAOkIpAAAAAAAAWEcoBQAAAAAAAOsIpQAAAAAAAGAdoRQAAAAAAACsI5QCAAAAAACAdYRSAAAAAAAAsI5QCgAAAAAAANYRSgEAAAAAAMA6QikAAAAAAABYRygFAAAAAAAA6wilAAAAAAAAYB2hFAAAAAAAAKwjlAIAAAAAAIB1hFIAAAAAAACwzuuh1IkTJ/TII4+oQYMGCg4OVsOGDTV27Fjl5uZ6e1cAAAAAAAAooyp6e4NPP/20Xn31Vb311ltq3ry51qxZo4EDB6patWoaPny4t3cHAAAAAACAMsjrodTXX3+tq6++Wr169ZIk1a9fX++9957WrFnj7V0BAAAAAACgjPL61/cuuugiffHFF9qyZYsk6bvvvtOKFSt0xRVXeHtXAAAAAAAAKKO8fqbUgw8+qAMHDqhJkyaqUKGCcnJy9OSTT+qmm24qsL3L5ZLL5XIvZ2VlebskoFRLTU0tsk14eLhiYmIsVAMAAAAAgB1eD6VmzpypadOmafr06WrevLk2bNigESNGKCoqSv3798/XPiUlRcnJyd4uAyj1crL3SQ6H+vbtW2TboOAQbf4plWAKAAAAAFBueD2Uuv/++zVq1CjdeOONkqSWLVtq586dSklJKTCUSkpKUmJions5KytL0dHR3i4LKHVyXdmSMQpLuFeBYYWP+eOZ6cqc97wyMjIIpQAAAAAA5YbXQ6nDhw8rIMDzUlUVKlRQbm5uge2dTqecTqe3ywDKjMCwaDkjz/F3GQAAAAAAWOX1UOrKK6/Uk08+qZiYGDVv3lzr16/XCy+8oEGDBnl7VwAAAAAAACijvB5KvfTSS3r00Uc1dOhQ/f7774qKitIdd9yhxx57zNu7AgAAAAAAQBnl9VAqNDRU48eP1/jx4729aQAAAAAAAJQTAUU3AQAAAAAAALyLUAoAAAAAAADWEUoBAAAAAADAOkIpAAAAAAAAWEcoBQAAAAAAAOsIpQAAAAAAAGAdoRQAAAAAAACsI5QCAADws5SUFDkcDo0YMcLfpQAAAFhDKAUAAOBHq1ev1qRJk3T++ef7uxQAAACrCKUAAAD8JDs7W7fccotef/111ahRw9/lAAAAWFXR3wUAAACcrYYNG6ZevXrpsssu0xNPPHHKti6XSy6Xy72clZXl6/IAlBNpaWnKyMgosl14eLhiYmIsVHT6UlNTi2xTFo6jJIpzzC6XS06n0yvtirO/kipPYxDeRSgFAADgBzNmzNC6deu0evXqYrVPSUlRcnKyj6sCUN6kpaWpcZOmOnrkcJFtg4JDtPmn1FIZCuRk75McDvXt27fItqX5OEqiJMcsR4Bkcr3XzovKyxiEbxBKAQAAWJaenq7hw4fr888/V1BQULFek5SUpMTERPdyVlaWoqOjfVUigHIiIyNDR48cVljCvQoMK/x3xvHMdGXOe14ZGRmlMhDIdWVLxpT54yiJ4h7zkW1rdGD5NK+385byMgbhG4RSAAAAlq1du1a///672rZt616Xk5OjZcuW6eWXX5bL5VKFChU8XuN0Oov11QwAKEhgWLSckef4u4wzVl6OoySKOubjmek+aedtZ+N7h6IRSgEAAFjWvXt3/fDDDx7rBg4cqCZNmujBBx/MF0gBAACUR4RSAAAAloWGhqpFixYe6ypXrqywsLB86wEAAMqrAH8XAAAAAAAAgLMPZ0oBAACUAkuWLPF3CQAAAFZxphQAAAAAAACsI5QCAAAAAACAdYRSAAAAAAAAsI5QCgAAAAAAANYRSgEAAAAAAMA6QikAAAAAAABYRygFAAAAAAAA6wilAAAAAAAAYB2hFAAAAAAAAKwjlAIAAAAAAIB1hFIAAAAAAACwjlAKAAAAAAAA1hFKAQAAAAAAwDpCKQAAAAAAAFhHKAUAAAAAAADrCKUAAAAAAABgHaEUAAAAAAAArCOUAgAAAAAAgHWEUgAAAAAAALCOUAoAAAAAAADWEUoBAAAAAADAOkIpAAAAAAAAWEcoBQAAAAAAAOsIpQAAAAAAAGAdoRQAAAAAAACsI5QCAAAAAACAdYRSAAAAAAAAsI5QCgAAAAAAANYRSgEAAAAAAMA6QikAAAAAAABYRygFAAAAAAAA6wilAAAAAAAAYB2hFAAAAAAAAKwjlAIAAAAAAIB1Pgmldu3apb59+yosLEwhISFq3bq11q5d64tdAQAAAAAAoAyq6O0N7tu3T126dFG3bt00f/58RURE6JdfflH16tW9vSsAAAAAAACUUV4PpZ5++mlFR0drypQp7nX169f39m4AAAAAAABQhnk9lJo7d6569uyp66+/XkuXLlXdunU1dOhQDR48uMD2LpdLLpfLvZyVleXtkuBnaWlpysjIKLKdy+WS0+ks1jbDw8MVExNzpqUBAAAAAAA/8XootW3bNk2cOFGJiYl66KGH9O233+qee+6R0+nUrbfemq99SkqKkpOTvV0GSom0tDQ1btJUR48cLrqxI0AyucXablBwiDb/lEowBQAAAABAGeX1UCo3N1ft2rXTuHHjJElt2rTRxo0bNXHixAJDqaSkJCUmJrqXs7KyFB0d7e2y4CcZGRk6euSwwhLuVWBY4e/rkW1rdGD5tCLbSdLxzHRlznteGRkZhFIAAAAAAJRRXg+l6tSpo2bNmnmsa9q0qWbNmlVge6fTWeyvbKHsCgyLljPynEKfP56ZXqx2AAAAAACgfAjw9ga7dOmizZs3e6zbsmWLYmNjvb0rAAAAAAAAlFFeD6VGjhypVatWady4cdq6daumT5+uSZMmadiwYd7eFQAAAAAAAMoor4dSF154oWbPnq333ntPLVq00OOPP67x48frlltu8fauAAAAAAAAUEZ5/ZpSkpSQkKCEhARfbBoAAAAAAADlgNfPlAIAAAAAAACKQigFAAAAAAAA6wilAAAALJs4caLOP/98Va1aVVWrVlWnTp00f/58f5cFAABgFaEUAACAZfXq1dNTTz2lNWvWaM2aNbr00kt19dVXa+PGjf4uDQAAwBqfXOgcAAAAhbvyyis9lp988klNnDhRq1atUvPmzf1UFQAAgF2EUgAAAH6Uk5OjDz74QIcOHVKnTp0KbedyueRyudzLWVlZNsoDUIS0tDRlZGQU2S48PFwxMTEWKoIkpaamFtmG96TsKs7PXXHGAPyPUAoAAMAPfvjhB3Xq1ElHjx5VlSpVNHv2bDVr1qzQ9ikpKUpOTrZYIYCipKWlqXGTpjp65HCRbYOCQ7T5p1RCEB/Lyd4nORzq27dvkW15T8qmkvzcofQjlAIAAPCDxo0ba8OGDdq/f79mzZql/v37a+nSpYUGU0lJSUpMTHQvZ2VlKTo62la5AAqQkZGho0cOKyzhXgWGFf7zeDwzXZnznldGRgYBiI/lurIlY3hPyrHi/twd2bZGB5ZPs1gZTgehFAAAgB9UqlRJ55xzjiSpXbt2Wr16tV588UW99tprBbZ3Op1yOp02SwRQTIFh0XJGnuPvMnAS3pPyr6j3+HhmusVqcLq4+x4AAEApYIzxuGYUAABAeceZUgAAAJY99NBDio+PV3R0tA4ePKgZM2ZoyZIlWrBggb9LAwAAsIZQCgAAwLLffvtN/fr10549e1StWjWdf/75WrBggS6//HJ/lwYAAGANoRQAAIBlb775pr9LAAAA8DuuKQUAAAAAAADrCKUAAAAAAABgHaEUAAAAAAAArCOUAgAAAAAAgHWEUgAAAAAAALCOUAoAAAAAAADWEUoBAAAAAADAOkIpAAAAAAAAWEcoBQAAAAAAAOsIpQAAAAAAAGBdRX8XAJQWqampZ/Q8AAAAAAAoPkIpnPVysvdJDof69u3r71IAAAAAADhrEErhrJfrypaMUVjCvQoMiy603ZFta3Rg+TSLlQEAAAAAUH4RSgH/X2BYtJyR5xT6/PHMdIvVAAAAAABQvnGhcwAAAAAAAFhHKAUAAAAAAADrCKUAAAAAAABgHaEUAAAAAAAArCOUAgAAAAAAgHWEUgAAAAAAALCOUAoAAAAAAADWEUoBAAAAAADAOkIpAAAAAAAAWEcoBQAAAAAAAOsIpQAAAAAAAGAdoRQAAAAAAACsI5QCAAAAAACAdYRSAAAAAAAAsI5QCgAAAAAAANYRSgEAAAAAAMA6QikAAAAAAABYRygFAAAAAAAA6wilAAAAAAAAYB2hFAAAAAAAAKwjlAIAAAAAAIB1hFIAAAAAAACwjlAKAAAAAAAA1hFKAQAAAAAAwDqfh1IpKSlyOBwaMWKEr3cFAAAAAACAMsKnodTq1as1adIknX/++b7cDQAAAAAAAMoYn4VS2dnZuuWWW/T666+rRo0avtoNAAAAAAAAyqCKvtrwsGHD1KtXL1122WV64oknCm3ncrnkcrncy1lZWb4qCeVMamrqGT1f1hTneMLDwxUTE2OhGgAAAAAAzoxPQqkZM2Zo3bp1Wr16dZFtU1JSlJyc7IsyUE7lZO+THA717dvX36VYUZLjDQoO0eafUgmmAAAAAAClntdDqfT0dA0fPlyff/65goKCimyflJSkxMRE93JWVpaio6O9XRbKkVxXtmSMwhLuVWBY4WPlyLY1OrB8msXKfKO4x3s8M12Z855XRkYGoRQAAAAAoNTzeii1du1a/f7772rbtq17XU5OjpYtW6aXX35ZLpdLFSpUcD/ndDrldDq9XQbOAoFh0XJGnlPo88cz0y1W43tFHS8AAAAAAGWJ10Op7t2764cffvBYN3DgQDVp0kQPPvigRyAFAAAAAACAs5PXQ6nQ0FC1aNHCY13lypUVFhaWbz0AAAAAAADOTgH+LgAAAOBsk5KSogsvvFChoaGKiIjQNddco82bN/u7LAAAAKt8cve9f1qyZImN3QAAAJQJS5cu1bBhw3ThhRfqxIkTevjhh9WjRw9t2rRJlStX9nd5AAAAVlgJpQAAAPC3BQsWeCxPmTJFERERWrt2rS655BI/VQUAAGAXoRQAAICfHThwQJJUs2bNQtu4XC65XC73clZWls/rkqS0tDRlZGQU2S48PFwxMTEWKoK38R6XPsV9T1wuV5F3Mk9NTS3RvovTvjyNhaKOt6T9dzbydh+W5vekLPy+LAs1noxQCgAAwI+MMUpMTNRFF110ypvCpKSkKDk52WJlf01sGzdpqqNHDhfZNig4RJt/Si0VE1wUH+9x6VOS90SOAMnkemW/Odn7JIdDffv2LbJteRgLJTleFMzbfVja35Oy8PuyLNT4T4RSAAAAfnTXXXfp+++/14oVK07ZLikpSYmJie7lrKwsRUdH+7S2jIwMHT1yWGEJ9yowrPB9Hc9MV+a855WRkeH3yS1Khve49Cnue3Jk2xodWD6t2O2KkuvKlow5a8ZCcY+3uP13NvJ2H5b296Qs/L4sCzX+E6EUAACAn9x9992aO3euli1bpnr16p2yrdPpLPJrOr4SGBYtZ+Q5ftk37OA9Ln2Kek+OZ6aXqJ239lveeLv/zka2x6C/35Oy8DNSFmrMQygFAABgmTFGd999t2bPnq0lS5aoQYMG/i4JAADAOkIpAAAAy4YNG6bp06fr448/VmhoqPbu3StJqlatmoKDg/1cHQAAgB0B/i4AAADgbDNx4kQdOHBAXbt2VZ06ddyPmTNn+rs0AAAAazhTCgAAwDJjjL9LAAAA8DvOlAIAAAAAAIB1hFIAAAAAAACwjlAKAAAAAAAA1hFKAQAAAAAAwDpCKQAAAAAAAFhHKAUAAAAAAADrCKUAAAAAAABgHaEUAAAAAAAArCOUAgAAAAAAgHWEUgAAAAAAALCOUAoAAAAAAADWEUoBAAAAAADAOkIpAAAAAAAAWEcoBQAAAAAAAOsIpQAAAAAAAGBdRX8XUBakpaUpIyOjyHbh4eGKiYmxUBFQuNTU1CLbFHes+nPs83MHAAAAAOUboVQR0tLS1LhJUx09crjItkHBIdr8Uyr/QYZf5GTvkxwO9e3bt8i2xRmr/hz7/NwBAAAAQPlHKFWEjIwMHT1yWGEJ9yowLLrQdscz05U573llZGTwn2P4Ra4rWzLGa2PVn2OfnzsAAAAAKP8IpYopMCxazshz/F0GUCRvj1V/jn1+7gAAAACg/OJC5wAAAAAAALCOUAoAAAAAAADWEUoBAAAAAADAOkIpAAAAAAAAWEcoBQAAAAAAAOsIpQAAAAAAAGAdoRQAAAAAAACsI5QCAAAAAACAdYRSAAAAAAAAsI5QCgAAAAAAANYRSgEAAAAAAMA6QikAAAAAAABYRygFAAAAAAAA6wilAAAAAAAAYB2hFAAAAAAAAKwjlAIAAAAAAIB1hFIAAAAAAACwjlAKAAAAAAAA1hFKAQAAAAAAwDpCKQAAAAAAAFhHKAUAAAAAAADrCKUAAAAAAABgHaEUAAAAAAAArPN6KJWSkqILL7xQoaGhioiI0DXXXKPNmzd7ezcAAAAAAAAow7weSi1dulTDhg3TqlWrtHDhQp04cUI9evTQoUOHvL0rAAAAAAAAlFEVvb3BBQsWeCxPmTJFERERWrt2rS655BJv7w4AAAAAAABlkM+vKXXgwAFJUs2aNX29KwAAAAAAAJQRXj9T6mTGGCUmJuqiiy5SixYtCmzjcrnkcrncy1lZWb4syUNaWpoyMjJO2SY1NdVSNWUP/Ve2FfXe+OK9K86Y8fe+XS6XnE5nke3Cw8MVExPjjdIkFb8+b++3PKEPAQAAgLLFp6HUXXfdpe+//14rVqwotE1KSoqSk5N9WUaB0tLS1LhJUx09ctj6vssD+q/sysneJzkc6tu3r9X9+nPMlGjfjgDJ5BbZLCg4RJt/SvVKuFGS+ry53/KEPkRZs2zZMj377LNau3at9uzZo9mzZ+uaa67xd1kAAABW+SyUuvvuuzV37lwtW7ZM9erVK7RdUlKSEhMT3ctZWVmKjo72VVluGRkZOnrksMIS7lVgWOH7O7JtjQ4sn+bzesoa+q/synVlS8ZYf++KO2b8ue+8/RbV7nhmujLnPa+MjAyvBBvFrc/b+y1P6EOUNYcOHVKrVq00cOBAXXfddf4uBwAAwC+8HkoZY3T33Xdr9uzZWrJkiRo0aHDK9k6ns1hflfGVwLBoOSPPKfT545npFqspe+i/sstf711R+/XnvvP2W5wafcFf+y1P6EOUFfHx8YqPj/d3GQAAAH7l9VBq2LBhmj59uj7++GOFhoZq7969kqRq1aopODjY27sDAAA4K/jzOpzwveJeF08q/rXx/HX9T29fx9Hb7Up7/5Un9CHKEm9fc7e47c/230leD6UmTpwoSeratavH+ilTpmjAgAHe3h0AAMBZwV/X4YTvlfS6i8W5Np6/ruXoi+s4ertdae6/8oQ+RFnh7WvulnR7Z/vvJJ98fQ8AAADe5a/rcML3SnLdxeJeG89f1//09nUcvd2utPdfeUIfoqzw9jV3i7s9id9Jko/vvgcAAADv8Pd1OOF7vrguXmm9hmRxr+Po7XYlxfVTzxx9iLLC22O1PP1O96UAfxcAAAAAAACAsw9nSgEAAFiWnZ2trVu3upe3b9+uDRs2qGbNmsW62CkAAEB5QCgFAABg2Zo1a9StWzf3ct61ovr376+pU6f6qSoAAAC7CKUAAAAs69q1KzeHAQAAZz2uKQUAAAAAAADrCKUAAAAAAABgHaEUAAAAAAAArCOUAgAAAAAAgHWEUgAAAAAAALCOUAoAAAAAAADWEUoBAAAAAADAOkIpAAAAAAAAWEcoBQAAAAAAAOsIpQAAAAAAAGAdoRQAAAAAAACsI5QCAAAAAACAdYRSAAAAAAAAsI5QCgAAAAAAANYRSgEAAAAAAMA6QikAAAAAAABYRygFAAAAAAAA6wilAAAAAAAAYB2hFAAAAAAAAKyr6O8CAJQPqampZ/Q8vCstLU0ZGRlFtnO5XHI6nV5rFx4erpiYmGLVCJRUccc14xAAAKBsIJQCcEZysvdJDof69u3r71Lw/6Wlpalxk6Y6euRw0Y0dAZLJ9Vq7oOAQbf4plUAAXleScc04BAAAKBsIpQCckVxXtmSMwhLuVWBYdKHtjmxbowPLp1ms7OyVkZGho0cOF/s98Va745npypz3vDIyMggD4HXFHdeMQwAAgLKDUAqAVwSGRcsZeU6hzx/PTLdYDaTivyfeagfYwDgEAAAoP7jQOQAAAAAAAKwjlAIAAAAAAIB1hFIAAAAAAACwjlAKAAAAAAAA1hFKAQAAAAAAwDpCKQAAAAAAAFhHKAUAAAAAAADrCKUAAAAAAABgHaEUAAAAAAAArCOUAgAAAAAAgHWEUgAAAAAAALCOUAoAAAAAAADWEUoBAAAAAADAOkIpAAAAAAAAWEcoBQAAAAAAAOsIpQAAAAAAAGAdoRQAAAAAAACsI5QCAAAAAACAdYRSAAAAAAAAsI5QCgAAAAAAANYRSgEAAAAAAMA6QikAAAAAAABYRygFAAAAAAAA6wilAAAAAAAAYJ3PQqkJEyaoQYMGCgoKUtu2bbV8+XJf7QoAAKBMYr4EAADOZj4JpWbOnKkRI0bo4Ycf1vr163XxxRcrPj5eaWlpvtgdAABAmcN8CQAAnO18Ekq98MILuu2223T77beradOmGj9+vKKjozVx4kRf7A4AAKDMYb4EAADOdhW9vcFjx45p7dq1GjVqlMf6Hj16aOXKlfnau1wuuVwu9/KBAwckSVlZWd4uzUN2dvZf+9+7VbnHjhba7nhmevHa/fmrJGnt2rXubRcmICBAubm5RdZYmttt3rxZkhf7r5jtfLFN2pWudiXaZjF/7rw+Xr38817s+vx1vD7oF8lPv5POst/VZaFdcduW9D3Ozs722Vwib7vGmNPeRknnS5J/5kzFni/xs3VG7Yo7vqXS/9nnt8+g0n4cJfgZoQ9p5+99085OO8n/v5NKxXzJeNmuXbuMJPPVV195rH/yySfNeeedl6/96NGjjSQePHjw4MGDB48y9UhPT7c2X2LOxIMHDx48ePAoi4+i5kteP1Mqj8Ph8Fg2xuRbJ0lJSUlKTEx0L+fm5urPP/9UWFhYge3Ls6ysLEVHRys9PV1Vq1b1dzl+RV/8jb74G33xN/rib/TF3+iLv/myL4wxOnjwoKKios54W8WdL0mla87EWDtz9OGZof/ODP135ujDM0P/nbnS3ofFnS95PZQKDw9XhQoVtHfvXo/1v//+u2rXrp2vvdPplNPp9FhXvXp1b5dVplStWrVUDip/oC/+Rl/8jb74G33xN/rib/TF33zVF9WqVTuj15d0viSVzjkTY+3M0Ydnhv47M/TfmaMPzwz9d+ZKcx8WZ77k9QudV6pUSW3bttXChQs91i9cuFCdO3f29u4AAADKHOZLAAAAPjhTSpISExPVr18/tWvXTp06ddKkSZOUlpamIUOG+GJ3AAAAZQ7zJQAAcLbzSSjVp08fZWZmauzYsdqzZ49atGihTz/9VLGxsb7YXbnhdDo1evTofKfmn43oi7/RF3+jL/5GX/yNvvgbffG3stAXZXm+VBb6t7SjD88M/Xdm6L8zRx+eGfrvzJWXPnQYcwb3MwYAAAAAAABOg9evKQUAAAAAAAAUhVAKAAAAAAAA1hFKAQAAAAAAwDpCKQAAAAAAAFhHKGXZhAkT1KBBAwUFBalt27Zavnx5oW0/+ugjXX755apVq5aqVq2qTp066bPPPrNYrW+VpC9WrFihLl26KCwsTMHBwWrSpIn+85//WKzWt0rSFyf76quvVLFiRbVu3dq3BVpUkr5YsmSJHA5HvsdPP/1ksWLfKem4cLlcevjhhxUbGyun06lGjRpp8uTJlqr1rZL0xYABAwocF82bN7dYse+UdFy8++67atWqlUJCQlSnTh0NHDhQmZmZlqr1rZL2xSuvvKKmTZsqODhYjRs31ttvv22p0rKpfv36Bf4sDRs2TFLBP2sdO3b0c9Wly4kTJ/TII4+oQYMGCg4OVsOGDTV27Fjl5ua62xhjNGbMGEVFRSk4OFhdu3bVxo0b/Vh16VGc/mMcntrBgwc1YsQIxcbGKjg4WJ07d9bq1avdzzP+ilZUHzIGPS1btkxXXnmloqKi5HA4NGfOHI/nizPmXC6X7r77boWHh6ty5cq66qqr9Ouvv1o8Cv/xRv917do135i88cYbLR5FCRlYM2PGDBMYGGhef/11s2nTJjN8+HBTuXJls3PnzgLbDx8+3Dz99NPm22+/NVu2bDFJSUkmMDDQrFu3znLl3lfSvli3bp2ZPn26+fHHH8327dvNO++8Y0JCQsxrr71muXLvK2lf5Nm/f79p2LCh6dGjh2nVqpWdYn2spH2xePFiI8ls3rzZ7Nmzx/04ceKE5cq973TGxVVXXWU6dOhgFi5caLZv326++eYb89VXX1ms2jdK2hf79+/3GA/p6emmZs2aZvTo0XYL94GS9sXy5ctNQECAefHFF822bdvM8uXLTfPmzc0111xjuXLvK2lfTJgwwYSGhpoZM2aYX375xbz33numSpUqZu7cuZYrLzt+//13j5+lhQsXGklm8eLFxhhj+vfvb/71r395tMnMzPRv0aXME088YcLCwsy8efPM9u3bzQcffGCqVKlixo8f727z1FNPmdDQUDNr1izzww8/mD59+pg6deqYrKwsP1ZeOhSn/xiHp3bDDTeYZs2amaVLl5qff/7ZjB492lStWtX8+uuvxhjGX3EU1YeMQU+ffvqpefjhh82sWbOMJDN79myP54sz5oYMGWLq1q1rFi5caNatW2e6detmWrVqVS7m+EXxRv/FxcWZwYMHe4zJ/fv3Wz6S4iOUsqh9+/ZmyJAhHuuaNGliRo0aVextNGvWzCQnJ3u7NOu80Rf//ve/Td++fb1dmnWn2xd9+vQxjzzyiBk9enS5CaVK2hd5odS+ffssVGdXSfti/vz5plq1auVyEnSmvy9mz55tHA6H2bFjhy/Ks6qkffHss8+ahg0beqz773//a+rVq+ezGm0paV906tTJ3HfffR7rhg8fbrp06eKzGsub4cOHm0aNGpnc3FxjzF//Ebv66qv9W1Qp16tXLzNo0CCPdddee617/pKbm2siIyPNU0895X7+6NGjplq1aubVV1+1WmtpVFT/GcM4PJXDhw+bChUqmHnz5nmsb9WqlXn44YcZf8VQVB8awxg8lX+GKsUZc/v37zeBgYFmxowZ7ja7du0yAQEBZsGCBdZqLw1Op/+M+SuUGj58uMVKzwxf37Pk2LFjWrt2rXr06OGxvkePHlq5cmWxtpGbm6uDBw+qZs2avijRGm/0xfr167Vy5UrFxcX5okRrTrcvpkyZol9++UWjR4/2dYnWnMm4aNOmjerUqaPu3btr8eLFvizTitPpi7lz56pdu3Z65plnVLduXZ133nm67777dOTIERsl+4w3fl+8+eabuuyyyxQbG+uLEq05nb7o3Lmzfv31V3366acyxui3337Thx9+qF69etko2WdOpy9cLpeCgoI81gUHB+vbb7/V8ePHfVZreXHs2DFNmzZNgwYNksPhcK9fsmSJIiIidN5552nw4MH6/fff/Vhl6XPRRRfpiy++0JYtWyRJ3333nVasWKErrrhCkrR9+3bt3bvXYyw7nU7FxcUV+3dceVZU/+VhHBbsxIkTysnJKfB334oVKxh/xVBUH+ZhDBZPccbc2rVrdfz4cY82UVFRatGixVk/LkvyM/vuu+8qPDxczZs313333aeDBw/aLrfYKvq7gLNFRkaGcnJyVLt2bY/1tWvX1t69e4u1jeeff16HDh3SDTfc4IsSrTmTvqhXr57++OMPnThxQmPGjNHtt9/uy1J97nT64ueff9aoUaO0fPlyVaxYfn6ET6cv6tSpo0mTJqlt27ZyuVx655131L17dy1ZskSXXHKJjbJ94nT6Ytu2bVqxYoWCgoI0e/ZsZWRkaOjQofrzzz/L9HWlzvR35549ezR//nxNnz7dVyVaczp90blzZ7377rvq06ePjh49qhMnTuiqq67SSy+9ZKNknzmdvujZs6feeOMNXXPNNbrgggu0du1aTZ48WcePH1dGRobq1Kljo/Qya86cOdq/f78GDBjgXhcfH6/rr79esbGx2r59ux599FFdeumlWrt2rZxOp/+KLUUefPBBHThwQE2aNFGFChWUk5OjJ598UjfddJMkucdrQWN5586d1ustbYrqP4lxeCqhoaHq1KmTHn/8cTVt2lS1a9fWe++9p2+++Ubnnnsu468YiupDiTFYEsUZc3v37lWlSpVUo0aNfG2K+//m8qq4P7O33HKLGjRooMjISP34449KSkrSd999p4ULF1qtt7jKz/9oy4iT/7oo/XWhsn+uK8h7772nMWPG6OOPP1ZERISvyrPqdPpi+fLlys7O1qpVqzRq1Cidc845HhOTsqq4fZGTk6Obb75ZycnJOu+882yVZ1VJxkXjxo3VuHFj93KnTp2Unp6u5557rkyHUnlK0he5ublyOBx69913Va1aNUnSCy+8oN69e+uVV15RcHCwz+v1pdP93Tl16lRVr15d11xzjY8qs68kfbFp0ybdc889euyxx9SzZ0/t2bNH999/v4YMGaI333zTRrk+VZK+ePTRR7V371517NhRxhjVrl1bAwYM0DPPPKMKFSrYKLdMe/PNNxUfH6+oqCj3uj59+rj/3aJFC7Vr106xsbH65JNPdO211/qjzFJn5syZmjZtmqZPn67mzZtrw4YNGjFihKKiotS/f393u9P9HVfeFaf/GIen9s4772jQoEGqW7euKlSooAsuuEA333yz1q1b527D+Du1ovqQMVhypzPmGJd/K6r/Bg8e7P53ixYtdO6556pdu3Zat26dLrjgAmt1Fhdf37MkPDxcFSpUyJfu/v777/mSzn+aOXOmbrvtNr3//vu67LLLfFmmFWfSFw0aNFDLli01ePBgjRw5UmPGjPFhpb5X0r44ePCg1qxZo7vuuksVK1ZUxYoVNXbsWH333XeqWLGivvzyS1ule92ZjIuTdezYUT///LO3y7PqdPqiTp06qlu3rjuQkqSmTZvKGFOm71ZyJuPCGKPJkyerX79+qlSpki/LtOJ0+iIlJUVdunTR/fffr/PPP189e/bUhAkTNHnyZO3Zs8dG2T5xOn0RHBysyZMn6/Dhw9qxY4fS0tJUv359hYaGKjw83EbZZdbOnTu1aNGiIs9OrlOnjmJjY8v872Bvuv/++zVq1CjdeOONatmypfr166eRI0cqJSVFkhQZGSlJZ/zZV14V1X8FYRx6atSokZYuXars7Gylp6e7v7KcdxaFxPgryqn6sCCMwcIVZ8xFRkbq2LFj2rdvX6Ftzlan+zN7wQUXKDAwsNSOSUIpSypVqqS2bdvmO2Vu4cKF6ty5c6Gve++99zRgwABNnz69zF8DJM/p9sU/GWPkcrm8XZ5VJe2LqlWr6ocfftCGDRvcjyFDhqhx48basGGDOnToYKt0r/PWuFi/fn2Z/xrO6fRFly5dtHv3bmVnZ7vXbdmyRQEBAapXr55P6/WlMxkXS5cu1datW3Xbbbf5skRrTqcvDh8+rIAAz4/6vLOCjDG+KdSCMxkXgYGBqlevnipUqKAZM2YoISEhXx/B05QpUxQREVHkPCQzM1Pp6ell/newNxX2M5ibmytJ7mDg5LF87NgxLV26tESffeVVUf1XEMZhwSpXrqw6depo3759+uyzz3T11Vcz/kqooD4sCGOwcMUZc23btlVgYKBHmz179ujHH38868fl6f7Mbty4UcePHy+9Y9LyhdXPanm3r37zzTfNpk2bzIgRI0zlypXdd4QaNWqU6devn7v99OnTTcWKFc0rr7xSZm7nWFwl7YuXX37ZzJ0712zZssVs2bLFTJ482VStWtV914uyrKR98U/l6e57Je2L//znP2b27Nlmy5Yt5scffzSjRo0yksysWbP8dQheU9K+OHjwoKlXr57p3bu32bhxo1m6dKk599xzze233+6vQ/Ca0/0Z6du3r+nQoYPtcn2qpH0xZcoUU7FiRTNhwgTzyy+/mBUrVph27dqZ9u3b++sQvKakfbF582bzzjvvmC1btphvvvnG9OnTx9SsWdNs377dT0dQNuTk5JiYmBjz4IMPeqw/ePCguffee83KlSvN9u3bzeLFi02nTp1M3bp1uZX8Sfr372/q1q1r5s2bZ7Zv324++ugjEx4ebh544AF3m6eeespUq1bNfPTRR+aHH34wN910U77be5+tiuo/xmHRFixYYObPn2+2bdtmPv/8c9OqVSvTvn17c+zYMWMM4684TtWHjMH8Dh48aNavX2/Wr19vJJkXXnjBrF+/3uzcudMYU7wxN2TIEFOvXj2zaNEis27dOnPppZeaVq1amRMnTvjrsKw50/7bunWrSU5ONqtXrzbbt283n3zyiWnSpIlp06ZNqe0/QinLXnnlFRMbG2sqVapkLrjgArN06VL3c/379zdxcXHu5bi4OCMp36N///72C/eBkvTFf//7X9O8eXMTEhJiqlatatq0aWMmTJhgcnJy/FC595WkL/6pPIVSxpSsL55++mnTqFEjExQUZGrUqGEuuugi88knn/ihat8o6bhITU01l112mQkODjb16tUziYmJ5vDhw5ar9o2S9sX+/ftNcHCwmTRpkuVKfa+kffHf//7XNGvWzAQHB5s6deqYW265xfz666+Wq/aNkvTFpk2bTOvWrU1wcLCpWrWqufrqq81PP/3kh6rLls8++8xIMps3b/ZYf/jwYdOjRw9Tq1YtExgYaGJiYkz//v1NWlqanyotnbKysszw4cNNTEyMCQoKMg0bNjQPP/ywcblc7ja5ublm9OjRJjIy0jidTnPJJZeYH374wY9Vlx5F9R/jsGgzZ840DRs2NJUqVTKRkZFm2LBhHn/gZvwV7VR9yBjMb/Hixaf8P2xxxtyRI0fMXXfdZWrWrGmCg4NNQkLCWdOnZ9p/aWlp5pJLLjE1a9Y0lSpVMo0aNTL33HOPyczM9NMRFc1hTBk+fx8AAAAAAABlEhdRAAAAAAAAgHWEUgAAAAAAALCOUAoAAAAAAADWEUoBAAAAAADAOkIpAAAAAAAAWEcoBQAAAAAAAOsIpQAAAAAAAGAdoRQAAAAAAACsI5QCAAAAAACAdYRSAAAAAAAAsI5QCgAAAAAAANYRSgEAAAAAAMC6/wfVF079ja1vQAAAAABJRU5ErkJggg==",
       "text/plain": [
        "<Figure size 1200x500 with 2 Axes>"
       ]
@@ -1314,7 +1137,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 21,
    "id": "c64052fb-cfa8-4b7e-a2f3-55df3a2b124d",
    "metadata": {},
    "outputs": [],


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Updated notebook `benchmark-deepseek-r1-distill-llama-llmperf.ipynb` to change the Linux permission of the Bash script from `0o755` to the less permissive `+x`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
