### PR TITLE
Added sample invocation with deepseek r1 chat template

### DIFF
--- a/custom-models/import_models/llama-3/benchmark-deepseek-r1-distill-llama-llmperf.ipynb
+++ b/custom-models/import_models/llama-3/benchmark-deepseek-r1-distill-llama-llmperf.ipynb
@@ -284,7 +284,7 @@
    "outputs": [],
    "source": [
     "bedrock = boto3.client('bedrock',region_name=region)\n",
-    "s3_uri = f's3://{sess.default_bucket()}/{s3_prefix}/' # S3 URI that contains th model artifacts\n",
+    "s3_uri = f's3://{sess.default_bucket()}/{s3_prefix}/'\n",
     "\n",
     "from sagemaker.utils import name_from_base\n",
     "\n",
@@ -441,10 +441,10 @@
     "                accept='application/json',\n",
     "                contentType='application/json'\n",
     "            )\n",
-    "            \n",
+    "\n",
     "            result = json.loads(response['body'].read().decode('utf-8'))\n",
-    "            return result\n",
-    "            \n",
+    "            return prompt, result\n",
+    "\n",
     "        except Exception as e:\n",
     "            print(f\"Attempt {attempt + 1} failed: {str(e)}\")\n",
     "            attempt += 1\n",
@@ -478,7 +478,9 @@
     "\"\"\"\n",
     "\n",
     "messages = [{\"role\": \"user\", \"content\": test_prompt}]\n",
-    "response = generate(messages)\n",
+    "prompt, response = generate(messages)\n",
+    "print(\"Test prompt\")\n",
+    "print(prompt)\n",
     "print(\"Model Response:\")\n",
     "print(response[\"generation\"])"
    ]
@@ -559,39 +561,36 @@
    "source": [
     "### Single invocation using LiteLLM\n",
     "\n",
-    "The Llama distill version of Deepseek R1 uses the Llama request/response spec. We define this part in the `model` param."
+    "DeepSeek R1 models use a custom request/response spec, that we must define in the `model` param. The `deepseek-ai/DeepSeek-R1-Distill-Llama-8B` model can be invoked with both the Llama chat template and the DeepSeek R1 chat template."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "975804ee-1263-473c-82f6-87e03309ac5a",
+   "id": "7cbe7fd0-a486-4e51-866b-4ce10b540dfe",
    "metadata": {},
    "outputs": [],
    "source": [
     "import os\n",
     "from litellm import completion\n",
     "\n",
-    "os.environ[\"AWS_ACCESS_KEY_ID\"] = AWS_ACCESS_KEY_ID\n",
-    "os.environ[\"AWS_SECRET_ACCESS_KEY\"] = AWS_SECRET_ACCESS_KEY\n",
-    "os.environ[\"AWS_REGION_NAME\"] = region\n",
-    "\n",
-    "response = completion(\n",
-    "    model=f\"bedrock/llama/{model_id}\",\n",
-    "    messages=[{\"role\": \"user\", \"content\": \"Tell me a knock-knock joke.\"},\n",
-    "              {\"role\": \"assistant\", \"content\": \"\"}],\n",
-    "    max_tokens=4096,\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "8c597f9b-0520-4c72-9f4e-099e69f7defa",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "print(response['choices'][0]['message']['content'])"
+    "while True:\n",
+    "    try:\n",
+    "        response = completion(\n",
+    "            model=f\"bedrock/deepseek_r1/{model_id}\",\n",
+    "            messages=[{\"role\": \"user\", \"content\": \"\"\"Given the following financial data:\n",
+    "        - Company A's revenue grew from $10M to $15M in 2023\n",
+    "        - Operating costs increased by 20%\n",
+    "        - Initial operating costs were $7M\n",
+    "        \n",
+    "        Calculate the company's operating margin for 2023. Please reason step by step.\"\"\"},\n",
+    "                      {\"role\": \"assistant\", \"content\": \"<think>\"}],\n",
+    "            max_tokens=4096,\n",
+    "        )\n",
+    "        print(response['choices'][0]['message']['content'])\n",
+    "        break\n",
+    "    except:\n",
+    "        time.sleep(60)"
    ]
   },
   {
@@ -607,7 +606,9 @@
    "id": "990ccbda-f60e-46d3-b43e-d1734f1bbd73",
    "metadata": {},
    "source": [
-    "We are going to define a Shell script that will run the `token_benchmark_ray.py` script that is part of the `LLMPerf` library. There will be some minor modifications to use our `LiteLLM` compatible model and to pass our AWS credentials as environment variables."
+    "We are going to define a Shell script that will run the `token_benchmark_ray.py` script that is part of the `LLMPerf` library. There will be some minor modifications to use our `LiteLLM` compatible model and to pass our AWS credentials as environment variables.\n",
+    "\n",
+    "We are going to run this test using the Llama chat template because, as of Feb 2025, `LLMPerf` does not support the DeepSeek R1 chat template."
    ]
   },
   {
@@ -676,12 +677,12 @@
     "    return results_dir\n",
     "\n",
     "results_dir = write_benchmarking_script(\n",
-    "    mean_input_tokens=200,\n",
+    "    mean_input_tokens=500,\n",
     "    stddev_input_tokens=25,\n",
-    "    mean_output_tokens=200,\n",
-    "    stddev_output_tokens=50,\n",
+    "    mean_output_tokens=1000,\n",
+    "    stddev_output_tokens=100,\n",
     "    num_concurrent_requests=2,\n",
-    "    num_requests_per_client=50\n",
+    "    num_requests_per_client=100\n",
     "    )"
    ]
   },
@@ -757,8 +758,9 @@
     "axes[0].hist(ttft_values, bins=50, edgecolor=\"black\")\n",
     "axes[0].set_title(\"Time to first token (s)\")\n",
     "axes[1].hist(throughput_values, bins=50, edgecolor=\"black\")\n",
-    "axes[1].set_title(\"Request throughput (tokens/s)\")\n",
+    "axes[1].set_title(\"Throughput (tokens/s)\")\n",
     "plt.tight_layout()\n",
+    "plt.savefig(\"token_benchmark.png\")\n",
     "plt.show()"
    ]
   },


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Changed the script in `custom-models/import_models/llama-3/benchmark-deepseek-r1-distill-llama-llmperf.ipynb` to showcase the use of the DeepSeek R1 chat template when invoking a custom model using LiteLLM.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
