### PR TITLE
Fix incorrect model reference in how_to_work_with_code_generation_w_bedrock.ipynb

### DIFF
--- a/docs/genai-use-cases/text-generation/how_to_work_with_code_generation_w_bedrock.md
+++ b/docs/genai-use-cases/text-generation/how_to_work_with_code_generation_w_bedrock.md
@@ -342,7 +342,7 @@ messages = [
     ]
 ```
 
-Let's use the Titan Text Large model: 
+Let's use the Anthropic's Claude 3 Sonnet model:
 
 
 ```python

--- a/genai-use-cases/text-generation/how_to_work_with_code_generation_w_bedrock.ipynb
+++ b/genai-use-cases/text-generation/how_to_work_with_code_generation_w_bedrock.ipynb
@@ -453,7 +453,7 @@
    "id": "1798b51b-e4b1-4822-a557-2e7733bc2931",
    "metadata": {},
    "source": [
-    "Let's use the Titan Text Large model: "
+    "Let's use the Anthropic's Claude 3 Sonnet model:"
    ]
   },
   {


### PR DESCRIPTION
*Description of changes:*

Hello, and thank you for the great content😀

While working on the "Generate Python Code with Converse" in "Gen AI Usecases," I noticed a minor issue.
- https://aws-samples.github.io/amazon-bedrock-samples/genai-use-cases/text-generation/how_to_work_with_code_generation_w_bedrock/
- https://github.com/aws-samples/amazon-bedrock-samples/blob/main//genai-use-cases/text-generation/how_to_work_with_code_generation_w_bedrock.ipynb

In "Use case 2 - SQL query generation," the documentation states:

>Let's use the Titan Text Large model:

However, the implementation actually uses the Claude v2 model, as seen in the modelId assignment:

```python
MODEL_IDS = [
    "amazon.titan-tg1-large",
    "anthropic.claude-3-sonnet-20240229-v1:0"
]

(snip)

response = boto3_bedrock.converse(
        modelId=MODEL_IDS[1],
        messages=messages,
        inferenceConfig=inference_config
)
```

This Pull Request corrects the reference to the model in the documentation to align with the actual implementation.

## Note

Following the guidelines in `CONTRIBUTING.md`, I attempted to exec the `jupyter nbconvert` command:

```sh
$ jupyter nbconvert --to markdown genai-use-cases/text-generation/how_to_work_with_code_generation_w_bedrock.ipynb
```

However, this resulted in many differences other than my intended change. To avoid unnecessary modifications, I have directly edited the markdown file instead. If I have misunderstood the correct process, please provide guidance on the best approach.

Thank you👍

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.