### PR TITLE
Add dataset validation script for open source model fine-tuning

### DIFF
--- a/custom-models/bedrock-fine-tuning/meta-llama/dataset_validation/README.md
+++ b/custom-models/bedrock-fine-tuning/meta-llama/dataset_validation/README.md
@@ -1,0 +1,47 @@
+## Dataset Validation for Fine-tuning Open Source Models
+Before you create a fine-tuning job in the Amazon Bedrock console, utilize the provided script to validate your dataset first, which would allow you to identify formatting errors (if any) faster and save costs.
+
+### Usage
+
+Install the latest version of python [here](https://www.python.org/downloads/) if you haven't already.
+
+Download the `dataset_validation` folder, `cd` into the root directory, and run the dataset validation script:
+
+```
+python3 dataset_validation.py -d <dataset type> -f <file path> -m <model name>
+```
+
+1. Dataset type options
+    - train
+    - validation
+
+2. Model name options
+    - meta.llama3-1-8b-instruct-v1
+    - meta.llama3-1-70b-instruct-v1
+    - meta.llama3-2-1b-instruct-v1
+    - meta.llama3-2-3b-instruct-v1
+    - meta.llama3-2-11b-instruct-v1
+    - meta.llama3-2-90b-instruct-v1
+
+
+### Features
+1. Validates the `JSONL` format
+2. Checks that the `train` dataset has <= 10k rows and `validation` dataset has <= 1k rows
+    - Each conversation should only take up 1 row
+3. For each row
+    - For models that use the prompt completion format, the script checks that
+        - required keys exists
+        - invalid types are not present
+    - For models that use the messaging format, the script checks that
+        - system array (if it exists) only contains 1 element
+        - required keys exists
+        - invalid types are not present
+        - given `role` for each message is supported
+        - messages with the `assistant` role do not contain an image
+
+### Limitations Not Validated by the Script
+1. Images
+    - Size <= 10 MB
+    - Format must be one of `png`, `jpeg`, `gif`, `webp`
+    - Dimensions <= 8192 x 8192 pixels
+2. Input token length of each dataset row <= 16K

--- a/custom-models/bedrock-fine-tuning/meta-llama/dataset_validation/constants.py
+++ b/custom-models/bedrock-fine-tuning/meta-llama/dataset_validation/constants.py
@@ -1,0 +1,25 @@
+from enum import StrEnum
+
+MAX_TRAIN_RECORDS = 10000
+MAX_VALIDATION_RECORDS = 1000
+TRAIN = "train"
+VALIDATION = "validation"
+
+
+class Keys(StrEnum):
+    PROMPT = "prompt"
+    COMPLETION = "completion"
+    SYSTEM = "system"
+    MESSAGES = "messages"
+    ROLE = "role"
+    CONTENT = "content"
+    TEXT = "text"
+    IMAGE = "image"
+    SOURCE = "source"
+    S3_LOCATION = "s3Location"
+    URI = "uri"
+
+
+class Roles(StrEnum):
+    USER = "user"
+    ASSISTANT = "assistant"

--- a/custom-models/bedrock-fine-tuning/meta-llama/dataset_validation/dataset_validation.py
+++ b/custom-models/bedrock-fine-tuning/meta-llama/dataset_validation/dataset_validation.py
@@ -1,0 +1,167 @@
+import argparse
+import json
+
+from constants import *
+from model_config.models_registry import MODELS
+from model_config.input_type import InputType
+from exceptions.invalid_row_exception import InvalidRowException
+from exceptions.missing_key_exception import MissingKeyException
+from exceptions.invalid_type_exception import InvalidTypeException
+
+
+def validate_system_prompt(row, index):
+    """
+    Validates the 'system' prompt of a given dataset row.
+
+    Checks whether the 'system' key exists and its value contains exactly one element.
+
+    Args:
+        row (dict): The dataset row to validate.
+        index (int): The index of the row in the dataset.
+
+    Raises:
+        InvalidRowException: If the 'system' array has more than one item.
+        MissingKeyException: If the 'system' key or any necessary subkey is missing.
+    """
+    try:
+        if Keys.SYSTEM in row and len(row[Keys.SYSTEM]) > 1:
+            row[Keys.SYSTEM][0][Keys.TEXT]
+            raise InvalidRowException(
+                "The system array should not contain more than 1 element.", index
+            )
+
+    except KeyError as e:
+        raise MissingKeyException(e, index)
+    except TypeError:
+        raise InvalidTypeException(index)
+
+
+def validate_record_count(record_count, dataset_type):
+    """
+    Validates the record count of the dataset based on its type.
+
+    Train datasets must contain less than or equal to 10k rows.
+    Validation datasets must contain less than or equal to 1k rows.
+
+    Args:
+        record_count (int): The total number of records in the dataset.
+        dataset_type (str): The type of the dataset, either TRAIN or VALIDATION.
+
+    Raises:
+        Exception: If the record count exceeds the maximum allowed for the specific dataset type.
+    """
+    if dataset_type == TRAIN and record_count > MAX_TRAIN_RECORDS:
+        raise Exception(
+            f"The {dataset_type} dataset contains {record_count} records, which exceeds the maximum allowed limit of {MAX_TRAIN_RECORDS}."
+        )
+
+    if dataset_type == VALIDATION and record_count > MAX_VALIDATION_RECORDS:
+        raise Exception(
+            f"The {dataset_type} dataset contains {record_count} records, which exceeds the maximum allowed limit of {MAX_VALIDATION_RECORDS}."
+        )
+
+
+def validate_converse(row, index):
+    """
+    Validates the 'messages' within a given dataset row.
+
+    Checks for supported roles and ensures that each row's structure fits the expected pattern for a conversational input.
+
+    Args:
+        row (dict): The dataset row to validate.
+        index (int): The index of the row in the dataset.
+
+    Raises:
+        InvalidRowException: If there are invalid roles, images where they shouldn't be, or multiple images in a single row.
+        MissingKeyException: If required keys are missing in the data structure.
+    """
+    try:
+        dialogue = row[Keys.MESSAGES]
+
+        for message in dialogue:
+            role = message[Keys.ROLE]
+            supported_roles = [member.value for member in list(Roles)]
+            if role not in supported_roles:
+                raise InvalidRowException(
+                    f"The role '{role}' is not supported. Supported roles are: {supported_roles}.",
+                    index,
+                )
+
+            for content in message[Keys.CONTENT]:
+                if Keys.IMAGE in content:
+                    if role == Roles.ASSISTANT:
+                        raise InvalidRowException(
+                            f"A message with the role '{Roles.ASSISTANT}' should not contain any images.",
+                            index,
+                        )
+                    content[Keys.IMAGE][Keys.SOURCE][Keys.S3_LOCATION][Keys.URI]
+                else:
+                    content[Keys.TEXT]
+
+    except KeyError as e:
+        raise MissingKeyException(e, index)
+    except TypeError:
+        raise InvalidTypeException(index)
+
+
+def validate_prompt_completion(row, index):
+    try:
+        row[Keys.PROMPT]
+        row[Keys.COMPLETION]
+    except KeyError as e:
+        raise MissingKeyException(e, index)
+    except TypeError:
+        raise InvalidTypeException(index)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="A script for dataset validation.")
+    parser.add_argument(
+        "-d",
+        "--dataset-type",
+        type=str,
+        choices=[TRAIN, VALIDATION],
+        required=True,
+        help="Specify the dataset type.",
+    )
+    parser.add_argument(
+        "-f",
+        "--file-path",
+        type=str,
+        required=True,
+        help="Provide the local path to your JSONL file.",
+    )
+    parser.add_argument(
+        "-m",
+        "--model-name",
+        type=str,
+        choices=list(MODELS.keys()),
+        required=True,
+        help="Specify the model name.",
+    )
+
+    args = parser.parse_args()
+    dataset_type, file_path, model_name = (
+        args.dataset_type,
+        args.file_path,
+        args.model_name,
+    )
+
+    model = MODELS[model_name]
+
+    with open(file_path, "r") as dataset:
+        validate_record_count(sum(1 for _ in dataset), dataset_type)
+        dataset.seek(0)
+        for index, object in enumerate(dataset):
+            row = json.loads(object)
+            validate_system_prompt(row, index)
+            if model.input_type == InputType.CONVERSE:
+                validate_converse(row, index)
+            if model.input_type == InputType.PROMPT_COMPLETION:
+                validate_prompt_completion(row, index)
+
+    print("Validation complete.")
+
+
+if __name__ == "__main__":
+    main()

--- a/custom-models/bedrock-fine-tuning/meta-llama/dataset_validation/exceptions/invalid_row_exception.py
+++ b/custom-models/bedrock-fine-tuning/meta-llama/dataset_validation/exceptions/invalid_row_exception.py
@@ -1,0 +1,10 @@
+class InvalidRowException(Exception):
+    def __init__(self, message, index):
+        super().__init__(message)
+        self.message = message
+        self.line_error_message = (
+            f" This error occured on line {index + 1} in the JSONL file."
+        )
+
+    def __str__(self):
+        return self.message + self.line_error_message

--- a/custom-models/bedrock-fine-tuning/meta-llama/dataset_validation/exceptions/invalid_type_exception.py
+++ b/custom-models/bedrock-fine-tuning/meta-llama/dataset_validation/exceptions/invalid_type_exception.py
@@ -1,0 +1,9 @@
+from .invalid_row_exception import InvalidRowException
+
+
+class InvalidTypeException(InvalidRowException):
+    def __init__(self, index):
+        super().__init__(
+            "Null values and strings are not accessible. Refer to the stack trace to identify the attempted dictionary access that raised this exception.",
+            index,
+        )

--- a/custom-models/bedrock-fine-tuning/meta-llama/dataset_validation/exceptions/missing_key_exception.py
+++ b/custom-models/bedrock-fine-tuning/meta-llama/dataset_validation/exceptions/missing_key_exception.py
@@ -1,0 +1,7 @@
+from .invalid_row_exception import InvalidRowException
+
+
+class MissingKeyException(InvalidRowException):
+    def __init__(self, key, index):
+        message = f"The '{key.args[0]}' key is missing in the input row."
+        super().__init__(message=message, index=index)

--- a/custom-models/bedrock-fine-tuning/meta-llama/dataset_validation/model_config/input_type.py
+++ b/custom-models/bedrock-fine-tuning/meta-llama/dataset_validation/model_config/input_type.py
@@ -1,0 +1,6 @@
+from enum import Enum
+
+
+class InputType(Enum):
+    CONVERSE = "CONVERSE"
+    PROMPT_COMPLETION = "PROMPT_COMPLETION"

--- a/custom-models/bedrock-fine-tuning/meta-llama/dataset_validation/model_config/model.py
+++ b/custom-models/bedrock-fine-tuning/meta-llama/dataset_validation/model_config/model.py
@@ -1,0 +1,12 @@
+from .input_type import InputType
+from .model_type import ModelType
+
+
+class Model:
+    def __init__(
+        self,
+        model_type: ModelType,
+        input_type: list[InputType],
+    ):
+        self.model_type = model_type
+        self.input_type = input_type

--- a/custom-models/bedrock-fine-tuning/meta-llama/dataset_validation/model_config/model_type.py
+++ b/custom-models/bedrock-fine-tuning/meta-llama/dataset_validation/model_config/model_type.py
@@ -1,0 +1,6 @@
+from enum import Enum
+
+
+class ModelType(Enum):
+    TEXT = "TEXT"
+    MULTIMODAL = "MULTIMODAL"

--- a/custom-models/bedrock-fine-tuning/meta-llama/dataset_validation/model_config/models_registry.py
+++ b/custom-models/bedrock-fine-tuning/meta-llama/dataset_validation/model_config/models_registry.py
@@ -1,0 +1,30 @@
+from .model import Model
+from .model_type import ModelType
+from .input_type import InputType
+
+MODELS = {
+    "meta.llama3-1-8b-instruct-v1": Model(
+        model_type=ModelType.TEXT,
+        input_type=InputType.PROMPT_COMPLETION,
+    ),
+    "meta.llama3-1-70b-instruct-v1": Model(
+        model_type=ModelType.TEXT,
+        input_type=InputType.PROMPT_COMPLETION,
+    ),
+    "meta.llama3-2-1b-instruct-v1": Model(
+        model_type=ModelType.TEXT,
+        input_type=InputType.CONVERSE,
+    ),
+    "meta.llama3-2-3b-instruct-v1": Model(
+        model_type=ModelType.TEXT,
+        input_type=InputType.CONVERSE,
+    ),
+    "meta.llama3-2-11b-instruct-v1": Model(
+        model_type=ModelType.MULTIMODAL,
+        input_type=InputType.CONVERSE,
+    ),
+    "meta.llama3-2-90b-instruct-v1": Model(
+        model_type=ModelType.MULTIMODAL,
+        input_type=InputType.CONVERSE,
+    ),
+}


### PR DESCRIPTION
*Description of changes:*
This pull request contains a validation script that enables users to verify their datasets prior to creating a fine-tuning job on Amazon Bedrock. Currently, the script is compatible only with datasets for open-source models like Meta Llama.
