### PR TITLE
Fixes for agent-blueprint-templates

### DIFF
--- a/agents-and-function-calling/bedrock-agents/agent-blueprint-templates/lib/stacks/01-agent-with-function-definitions/agent-with-function-definition-stack.ts
+++ b/agents-and-function-calling/bedrock-agents/agent-blueprint-templates/lib/stacks/01-agent-with-function-definitions/agent-with-function-definition-stack.ts
@@ -5,8 +5,7 @@ import { readFileSync } from 'fs';
 import { Runtime } from 'aws-cdk-lib/aws-lambda';
 import { Effect, ManagedPolicy, PolicyDocument, PolicyStatement } from 'aws-cdk-lib/aws-iam';
 import { RDSDatabaseForAgentWithFD } from '../01-agent-with-function-definitions/rds-database-fd-construct';
-import {BedrockAgentBlueprintsConstruct, AgentDefinitionBuilder, AgentActionGroup} from '@aws/agents-and-function-calling-for-amazon-bedrock-blueprints';
-
+import {BedrockAgentBlueprintsConstruct, AgentDefinitionBuilder, AgentActionGroup} from '@aws/agents-for-amazon-bedrock-blueprints';
 
 export class AgentWithFunctionDefinitionStack extends Stack {
     constructor(scope: Construct, id: string, props?: StackProps) {

--- a/agents-and-function-calling/bedrock-agents/agent-blueprint-templates/lib/stacks/02-agent-with-return-of-control/agent-with-ROC-stack.ts
+++ b/agents-and-function-calling/bedrock-agents/agent-blueprint-templates/lib/stacks/02-agent-with-return-of-control/agent-with-ROC-stack.ts
@@ -1,7 +1,7 @@
 import { Stack, StackProps } from 'aws-cdk-lib'; 
 import { Construct } from 'constructs';
 import { VacationAPILambdaSetup } from './vacation-api-lambda-construct';
-import {BedrockAgentBlueprintsConstruct, AgentDefinitionBuilder, AgentActionGroup} from '@aws/agents-and-function-calling-for-amazon-bedrock-blueprints';
+import {BedrockAgentBlueprintsConstruct, AgentDefinitionBuilder, AgentActionGroup} from '@aws/agents-for-amazon-bedrock-blueprints';
 
 export class AgentWithROCStack extends Stack {
     constructor(scope: Construct, id: string, props?: StackProps) {

--- a/agents-and-function-calling/bedrock-agents/agent-blueprint-templates/lib/stacks/02-agent-with-return-of-control/rds-database-roc-construct.ts
+++ b/agents-and-function-calling/bedrock-agents/agent-blueprint-templates/lib/stacks/02-agent-with-return-of-control/rds-database-roc-construct.ts
@@ -1,8 +1,10 @@
 
 import { Duration, RemovalPolicy, aws_rds as rds } from "aws-cdk-lib";
+import { SubnetType, Vpc } from "aws-cdk-lib/aws-ec2";
 import { Effect, ManagedPolicy, PolicyDocument, PolicyStatement, Role, ServicePrincipal } from "aws-cdk-lib/aws-iam";
 import { Runtime } from "aws-cdk-lib/aws-lambda";
 import { NodejsFunction } from "aws-cdk-lib/aws-lambda-nodejs";
+import { ClusterInstance } from "aws-cdk-lib/aws-rds";
 import { AwsCustomResource, AwsCustomResourcePolicy, PhysicalResourceId } from "aws-cdk-lib/custom-resources";
 import { Construct } from "constructs";
 import { join } from "path";
@@ -11,7 +13,7 @@ import { join } from "path";
 
 export class RDSDatabaseForAgentWithROC extends Construct {
     public readonly dbSecret: rds.DatabaseSecret;
-    public readonly dbCluster: rds.ServerlessCluster;
+    public readonly dbCluster: rds.DatabaseCluster;
     public readonly AuroraClusterArn: string;
     public readonly AuroraDatabaseSecretArn: string;
 
@@ -23,8 +25,10 @@ export class RDSDatabaseForAgentWithROC extends Construct {
             username: 'clusteradmin',
         });
 
+        const defaultVpc = Vpc.fromLookup(this, 'defaultVpc', {isDefault: true});
+
         // Define Aurora Serverless cluster
-        this.dbCluster = new rds.ServerlessCluster(this, 'AuroraClusterForAgentWithROC', {
+        this.dbCluster = new rds.DatabaseCluster(this, 'AuroraClusterForAgentWithROC', {
             engine: rds.DatabaseClusterEngine.auroraPostgres({
                 version: rds.AuroraPostgresEngineVersion.VER_13_12,
             }),
@@ -33,6 +37,11 @@ export class RDSDatabaseForAgentWithROC extends Construct {
             credentials: rds.Credentials.fromSecret(this.dbSecret),
             enableDataApi: true,
             removalPolicy: RemovalPolicy.DESTROY,
+            serverlessV2MinCapacity: 0.5,
+            serverlessV2MaxCapacity: 8,
+            vpc: defaultVpc,
+            vpcSubnets: { subnetType: SubnetType.PUBLIC },
+            writer: ClusterInstance.serverlessV2('writer', { }),
         });
 
 
@@ -62,7 +71,7 @@ export class RDSDatabaseForAgentWithROC extends Construct {
 
 
         // Create a custom resource to trigger the execution of populateSampleDataFunction Lambda function whenever the stack is updated
-        new AwsCustomResource(this, 'TriggerPopulateDataFunction', {
+        const populateResource = new AwsCustomResource(this, 'TriggerPopulateDataFunction', {
             onUpdate: {
                 service: 'Lambda',
                 action: 'InvokeCommand',
@@ -74,6 +83,7 @@ export class RDSDatabaseForAgentWithROC extends Construct {
             },
             policy: customResourcePolicy,
         });
+        populateResource.node.addDependency(this.dbCluster);
 
         this.AuroraClusterArn = this.dbCluster.clusterArn;
         this.AuroraDatabaseSecretArn = this.dbSecret.secretArn;

--- a/agents-and-function-calling/bedrock-agents/agent-blueprint-templates/lib/stacks/03-agent-with-kb-and-guardrails/agent-with-kb-and-guardrails-stack.ts
+++ b/agents-and-function-calling/bedrock-agents/agent-blueprint-templates/lib/stacks/03-agent-with-kb-and-guardrails/agent-with-kb-and-guardrails-stack.ts
@@ -6,7 +6,7 @@ import { Runtime } from 'aws-cdk-lib/aws-lambda';
 // import { BedrockAgentBlueprintsConstruct } from '../../../../../agents-and-function-calling-for-amazon-bedrock-blueprints/bin/BedrockAgentBlueprintsConstruct';
 // import { BedrockGuardrailsBuilder, FilterType, ManagedWordsTypes, PIIAction, PIIType } from '../../../../../agents-and-function-calling-for-amazon-bedrock-blueprints/bin/constructs/BedrockGuardrailsBuilder';
 
-import {BedrockAgentBlueprintsConstruct, AgentDefinitionBuilder, AgentActionGroup, AgentKnowledgeBase, BedrockGuardrailsBuilder, FilterType, ManagedWordsTypes, PIIAction, PIIType} from '@aws/agents-and-function-calling-for-amazon-bedrock-blueprints';
+import {BedrockAgentBlueprintsConstruct, AgentDefinitionBuilder, AgentActionGroup, AgentKnowledgeBase, BedrockGuardrailsBuilder, FilterType, ManagedWordsTypes, PIIAction, PIIType} from '@aws/agents-for-amazon-bedrock-blueprints';
 
 import {  join } from "path";
 import { ManagedPolicy } from 'aws-cdk-lib/aws-iam';

--- a/agents-and-function-calling/bedrock-agents/agent-blueprint-templates/lib/stacks/04-agent-with-lambda-parser/agent-with-lambda-parser-stack.ts
+++ b/agents-and-function-calling/bedrock-agents/agent-blueprint-templates/lib/stacks/04-agent-with-lambda-parser/agent-with-lambda-parser-stack.ts
@@ -1,6 +1,6 @@
 import { Stack, StackProps } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
-import { BedrockAgentBlueprintsConstruct, AgentDefinitionBuilder, AgentActionGroup, PromptConfig_Override, PromptStateConfig, PromptType} from '@aws/agents-and-function-calling-for-amazon-bedrock-blueprints';
+import { BedrockAgentBlueprintsConstruct, AgentDefinitionBuilder, AgentActionGroup, PromptConfig_Override, PromptStateConfig, PromptType} from '@aws/agents-for-amazon-bedrock-blueprints';
 import { Runtime } from 'aws-cdk-lib/aws-lambda';
 import { NodejsFunction } from 'aws-cdk-lib/aws-lambda-nodejs';
 import { join } from 'path';

--- a/agents-and-function-calling/bedrock-agents/agent-blueprint-templates/lib/stacks/05-agent-with-classification-instructions/agent-with-classification-instructions-stack.ts
+++ b/agents-and-function-calling/bedrock-agents/agent-blueprint-templates/lib/stacks/05-agent-with-classification-instructions/agent-with-classification-instructions-stack.ts
@@ -1,6 +1,6 @@
 import * as cdk from 'aws-cdk-lib';
 import { Construct } from 'constructs';
-import {BedrockAgentBlueprintsConstruct, AgentDefinitionBuilder, BedrockKnowledgeBaseModels} from '@aws/agents-and-function-calling-for-amazon-bedrock-blueprints';
+import {BedrockAgentBlueprintsConstruct, AgentDefinitionBuilder, BedrockKnowledgeBaseModels} from '@aws/agents-for-amazon-bedrock-blueprints';
 
 export class AgentWithSimpleClassificationStack extends cdk.Stack {
     constructor(scope: Construct, id: string, props?: cdk.StackProps) {


### PR DESCRIPTION
*Description of changes:*

* `agents-for-amazon-bedrock-blueprints` imports were accidentally renamed when the code was moved folders
* updated CDK code to use Aurora serverless v2, v1 is no longer supported

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
