### PR TITLE
langfuse-observability-bedrock-agents-notebook

### DIFF
--- a/evaluation-observe/agent-observability/trace-bedrock-agents-with-langfuse.ipynb
+++ b/evaluation-observe/agent-observability/trace-bedrock-agents-with-langfuse.ipynb
@@ -1,0 +1,545 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Amazon Bedrock Recipe: Langfuse Integration with Bedrock Agents\n",
+    "\n",
+    "## Overview\n",
+    "This recipe implements an OpenTelemetry-based tracing and monitoring system for Amazon Bedrock Agents through Langfuse integration. It creates hierarchical trace structures to track agent performance metrics including token usage, latency measurements, and execution durations across preprocessing, orchestration, and postprocessing phases. It processes both streaming and non-streaming responses, generating spans with operation attributes such as timing data, error states, and response content. The error handling and logging functions enable systematic debugging, performance monitoring, and audit trail maintenance. \n",
+    "\n",
+    "### Context\n",
+    "Langfuse integration enables tracing, monitoring, and analyzing the performance and behavior of your Bedrock Agents. This helps in understanding agent interactions, debugging issues, and optimizing performance and can be used with single agents, multi-agent collaboration (MAC), or with inline agents. When using Langfuse you can utilize the cloud platform or a self hosted option on a container. \n",
+    "\n",
+    "#### Use Case\n",
+    "To demonstrate the integration between Langfuse and Amazon Bedrock Agents providing observability outside of AWS tooling. \n",
+    "\n",
+    "#### Implementation\n",
+    "In this notebook we will show how to integrate Amazon Bedrock Agents and Langfuse using both the Langfuse cloud platform and self-hosted option in a container running in AWS. We will configure agent observability, send traces to Langfuse, and validate the results using a single agent.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prerequisites\n",
+    "AWS account with appropriate IAM permissions for Amazon Bedrock Agents and Model Access as well as appropriate permission to deploy containers if using the Langfuse self-hosted option."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Python Dependencies\n",
+    "\n",
+    "To run this notebook, you'll need to install some libraries in your environment:\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "%pip install -r requirements.txt"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### AWS Credentials\n",
+    "Before using Amazon Bedrock, ensure that your AWS credentials are configured correctly. You can set them up using the AWS CLI or by setting environment variables. For this notebook assumes that the credentials are already configured.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import boto3\n",
+    "\n",
+    "# Create the client to invoke Agents in Amazon Bedrock:\n",
+    "br_agents_runtime = boto3.client(\"bedrock-agent-runtime\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Amazon Bedrock Agent\n",
+    "\n",
+    "\n",
+    "We assume you've already created an [Amazon Bedrock Agent](https://docs.aws.amazon.com/bedrock/latest/userguide/agents.html). If you don't have one already you can follow the **[instructions here]()** to set up an example agent.\n",
+    "\n",
+    "Configure your agent's **ID** and (optionally) alias ID in the cell below. You can find these by looking up your agent in the [\"Agents\" page on the AWS Console for Amazon Bedrock](https://console.aws.amazon.com/bedrock/home?#/agents) or CLI.\n",
+    "\n",
+    "The Agent ID should be ten characters, uppercase, and alphanumeric. If you haven't created an Alias for your agent yet, you can use `TSTALIASID` to reference the latest saved development version."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "agent_id = \"\"  # <- Configure your Bedrock Agent ID\n",
+    "agent_alias_id = \"TSTALIASID\"  # <- Optionally set a different Alias ID if you have one"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Before moving on lets validate invoke agent is working correctly. The response is not important we are simply testing the API call. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"Trying to invoke alias {agent_alias_id} of agent {agent_id}...\")\n",
+    "agent_resp = br_agents_runtime.invoke_agent(\n",
+    "    agentAliasId=agent_alias_id,\n",
+    "    agentId=agent_id,\n",
+    "    inputText=\"Hello!\",\n",
+    "    sessionId=\"dummy-session\",\n",
+    ")\n",
+    "if \"completion\" in agent_resp:\n",
+    "    print(\"✅ Got response\")\n",
+    "else:\n",
+    "    raise ValueError(f\"No 'completion' in agent response:\\n{agent_resp}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Langfuse API keys\n",
+    "\n",
+    "There are multiple ways you can use Langfuse - and we'll first need to configure where your Langfuse is hosted:\n",
+    "\n",
+    "### Langfuse Cloud\n",
+    "\n",
+    "If you're directly using [Langfuse Cloud](https://langfuse.com/pricing), your `langfuse_api_url` will be either\n",
+    "- `https://cloud.langfuse.com/api/public/otel`\n",
+    "- `https://us.cloud.langfuse.com/api/public/otel`\n",
+    "- ...or similar.\n",
+    "\n",
+    "### Self-hosted\n",
+    "\n",
+    "If you want to deploy the Open Source version of Langfuse in your own AWS Account, you can use the quick-start [CloudFormation](https://aws.amazon.com/cloudformation/resources/templates/) template provided below:\n",
+    "\n",
+    "> ⚠️ **But first, note:**\n",
+    "> - This sample deployment is intended for initial experimentation, and doesn't fully implement scalability and security best-practices. It should not be used in mission-critical or production environments. For more details, see the [solution source code TODO UPDATE LINK]() and Langfuse's own [documentation on self-hosting](https://langfuse.com/self-hosting).\n",
+    "> - The solution uses resources outside of the AWS Free Tier, and the **estimated cost** to run is around $4-10 per full day (which may vary depending on your usage). When you delete the created stack(s), any data you stored in your Langfuse instance will also be deleted.\n",
+    "> - To deploy this stack, you'll need IAM permissions to manage AWS IAM roles and policies, AWS Lambda Functions, and AWS CodeBuild projects in your account. Find more information about the architecture and deployment [here](https://github.com/aws-samples/amazon-bedrock-samples/tree/main/evaluation-observe/deploy-langfuse-on-ecs-fargate-with-typescript-cdk).\n",
+    "\n",
+    "[![Launch Stack](https://s3.amazonaws.com/cloudformation-examples/cloudformation-launch-stack.png)](https://console.aws.amazon.com/cloudformation/home?#/stacks/create/review?templateURL=https://console.aws.amazon.com/cloudformation/home?#/stacks/create/review?templateURL=https://aws-blogs-artifacts-public.s3.us-east-1.amazonaws.com/artifacts/ML-18524/langfuse-bootstrap.yml&stackName=LangfuseBootstrap \"Launch Stack\")\n",
+    "\n",
+    "Once the stack deploys successfully, look up the `LangfuseUrl` output in the created `LangfuseDemo` stack.\n",
+    "\n",
+    "You'll need to visit this URL to sign up a user account and create an Organization and Project in the Langfuse UI. Take note of the **project name** as you will need that later in the code.\n",
+    "\n",
+    "For your `langfuse_api_url` below, use the same URL with an `/api/public/otel` suffix at the end: It should be something like `https://123abcdefghijk.cloudfront.net/api/public/otel`.\n",
+    "\n",
+    "\n",
+    "### AWS Marketplace\n",
+    "\n",
+    "For production-ready deployments of Langfuse on your own AWS Account, check out the [offerings from Langfuse on the AWS Marketplace](https://aws.amazon.com/marketplace/seller-profile?id=seller-nmyz7ju7oafxu).\n",
+    "\n",
+    "---\n",
+    "\n",
+    "However your Langfuse environment is deployed, set up the target URL below:\n",
+    "\n",
+    "> ⚠️ **Note:** If you change this URL after using it, you'll need to **restart your notebook kernel**. Otherwise, you'll see a message like `opentelemetry.trace - WARNING - Overriding of current TracerProvider is not allowed` when you try to use the new one, and the client won't work correctly."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "langfuse_api_url = \"xxx/api/public/otel\"  # <- Replace as described above"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Once your Langfuse environment is set up and you've signed in to the UI, you'll need to set up an **API key pair** for your particular Organization and Project (create a new project if you don't have one already).\n",
+    "\n",
+    "For more information, see the [FAQ: Where are my Langfuse API keys](https://langfuse.com/faq/all/where-are-langfuse-api-keys) and Langfuse's [getting started documentation](https://langfuse.com/docs/get-started)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "langfuse_public_key = \"xxx\"  # <- Configure your own key here\n",
+    "langfuse_secret_key = \"xxx\"  # <- Configure your own key here"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Setting up agent tracing\n",
+    "\n",
+    "With all the pre-requisites in place, we're ready to recording traces from your Bedrock Agent into Langfuse.\n",
+    "\n",
+    "First, let's load the libraries:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import time\n",
+    "import boto3\n",
+    "import uuid\n",
+    "import json\n",
+    "from core.timer_lib import timer\n",
+    "from core import instrument_agent_invocation, flush_telemetry"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Now lets define a wrapper function\n",
+    "Here we create a wrapper function that is used to Invoke the Amazon Bedrock Agent with instrumentation for Langfuse on the Amazon Bedrock Agents runtime API.\n",
+    "\n",
+    "1. Instrumentation for monitoring\n",
+    "2. Configurable streaming support\n",
+    "3. Trace enabling for debugging\n",
+    "4. Flexible parameter handling through kwargs\n",
+    "5. Proper logging of configuration states\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@instrument_agent_invocation\n",
+    "def invoke_bedrock_agent(\n",
+    "    inputText: str, agentId: str, agentAliasId: str, sessionId: str, **kwargs\n",
+    "):\n",
+    "    \"\"\"Invoke a Bedrock Agent with instrumentation for Langfuse.\"\"\"\n",
+    "    # Create Bedrock client\n",
+    "    bedrock_rt_client = boto3.client(\"bedrock-agent-runtime\")\n",
+    "    use_streaming = kwargs.get(\"streaming\", False)\n",
+    "    invoke_params = {\n",
+    "        \"inputText\": inputText,\n",
+    "        \"agentId\": agentId,\n",
+    "        \"agentAliasId\": agentAliasId,\n",
+    "        \"sessionId\": sessionId,\n",
+    "        \"enableTrace\": True,  # Required for instrumentation\n",
+    "    }\n",
+    "\n",
+    "    # Add streaming configurations if needed\n",
+    "    if use_streaming:\n",
+    "        invoke_params[\"streamingConfigurations\"] = {\n",
+    "            \"applyGuardrailInterval\": 10,\n",
+    "            \"streamFinalResponse\": True,\n",
+    "        }\n",
+    "    response = bedrock_rt_client.invoke_agent(**invoke_params)\n",
+    "    return response"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Now lets create a wrapper function to handle the responses\n",
+    "\n",
+    "1. Instrumentation for monitoring\n",
+    "2. Configurable streaming support\n",
+    "3. Trace enabling for debugging\n",
+    "4. Flexible parameter handling through kwargs\n",
+    "5. Proper logging of configuration states\n",
+    "\n",
+    "It's particularly useful for:\n",
+    "\n",
+    "1. Real-time processing of large responses\n",
+    "2. Interactive applications requiring immediate feedback\n",
+    "3. Debugging and monitoring streaming responses\n",
+    "4. Ensuring proper text encoding/decoding"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def process_streaming_response(stream):\n",
+    "    \"\"\"Process a streaming response from Bedrock Agent.\"\"\"\n",
+    "    full_response = \"\"\n",
+    "    try:\n",
+    "        for event in stream:\n",
+    "            # Convert event to dictionary if it's a botocore Event object\n",
+    "            event_dict = (\n",
+    "                event.to_response_dict()\n",
+    "                if hasattr(event, \"to_response_dict\")\n",
+    "                else event\n",
+    "            )\n",
+    "            if \"chunk\" in event_dict:\n",
+    "                chunk_data = event_dict[\"chunk\"]\n",
+    "                if \"bytes\" in chunk_data:\n",
+    "                    output_bytes = chunk_data[\"bytes\"]\n",
+    "                    # Convert bytes to string if needed\n",
+    "                    if isinstance(output_bytes, bytes):\n",
+    "                        output_text = output_bytes.decode(\"utf-8\")\n",
+    "                    else:\n",
+    "                        output_text = str(output_bytes)\n",
+    "                    full_response += output_text\n",
+    "    except Exception as e:\n",
+    "        print(f\"\\nError processing stream: {e}\")\n",
+    "    return full_response"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import base64\n",
+    "\n",
+    "start = time.time()\n",
+    "with open('config.json', 'r') as config_file:\n",
+    "    config = json.load(config_file)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Langfuse Configuration"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# For Langfuse specifically but you can add any other observability provider:\n",
+    "if \"langfuse\" in config:\n",
+    "    os.environ[\"OTEL_SERVICE_NAME\"] = 'Langfuse'\n",
+    "    os.environ[\"DEPLOYMENT_ENVIRONMENT\"] = config[\"langfuse\"][\"environment\"]\n",
+    "    project_name = config[\"langfuse\"][\"project_name\"]\n",
+    "    environment = config[\"langfuse\"][\"environment\"]\n",
+    "    langfuse_public_key = config[\"langfuse\"][\"langfuse_public_key\"]\n",
+    "    langfuse_secret_key = config[\"langfuse\"][\"langfuse_secret_key\"]\n",
+    "    langfuse_api_url = config[\"langfuse\"][\"langfuse_api_url\"]\n",
+    "    \n",
+    "    # Create auth header\n",
+    "    auth_token = base64.b64encode(\n",
+    "        f\"{langfuse_public_key}:{langfuse_secret_key}\".encode()\n",
+    "    ).decode()\n",
+    "    \n",
+    "    # Set OpenTelemetry environment variables for Langfuse\n",
+    "    os.environ[\"OTEL_EXPORTER_OTLP_ENDPOINT\"] = f\"{langfuse_api_url}/api/public/otel/v1/traces\"\n",
+    "    os.environ[\"OTEL_EXPORTER_OTLP_HEADERS\"] = f\"Authorization=Basic {auth_token}\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Update fields to pass to Agent and User \n",
+    "The next code block will require some editing before running. Here we will set parameters used by Langfuse to track traces\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "# Langfuse configuration\n",
+    "project_name = \"xxx\" #Enter your Langfuse Project name that you created \n",
+    "environment = \"default\"  #Enter the env name\n",
+    "\n",
+    "# User information\n",
+    "user_id = \"xxx\" #This will be used in the Langfuse UI to filter traces\n",
+    "\n",
+    "# Foundation Model used by the agent (used to estimate costs)\n",
+    "agent_model_id = \"xxx\"  #eg \"claude-3-5-sonnet-20241022-v2:0\"\n",
+    "    "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Agent configuration\n",
+    "agentId = config[\"agent\"][\"agentId\"]\n",
+    "agentAliasId = config[\"agent\"][\"agentAliasId\"]\n",
+    "sessionId = f\"session-{int(time.time())}\"\n",
+    "\n",
+    "# User information\n",
+    "userId = config[\"user\"][\"userId\"]  \n",
+    "agent_model_id = config[\"user\"][\"agent_model_id\"]\n",
+    "\n",
+    "# Tags for filtering in Langfuse\n",
+    "tags = [\"bedrock-agent\", \"example\", \"development\"]\n",
+    "\n",
+    "# Generate a custom trace ID\n",
+    "trace_id = str(uuid.uuid4())\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Prompt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Your prompt and streaming mode\n",
+    "question = \"xxx\" # your prompt to the agent\n",
+    "streaming = False\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Invoke Agent Function\n",
+    "There we pass all the parameters Invoking the agent along with the observability integration with Langfuse."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Single invocation that works for both streaming and non-streaming\n",
+    "response = invoke_bedrock_agent(\n",
+    "    inputText=question,\n",
+    "    agentId=agentId,\n",
+    "    agentAliasId=agentAliasId,\n",
+    "    sessionId=sessionId,\n",
+    "    show_traces=True,\n",
+    "    SAVE_TRACE_LOGS=True,\n",
+    "    userId=userId,\n",
+    "    tags=tags,\n",
+    "    trace_id=trace_id,\n",
+    "    project_name=project_name,\n",
+    "    environment=environment,\n",
+    "    langfuse_public_key=langfuse_public_key,\n",
+    "    langfuse_secret_key=langfuse_secret_key,\n",
+    "    langfuse_api_url=langfuse_api_url,\n",
+    "    streaming=streaming,\n",
+    "    model_id=agent_model_id,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Response Handling\n",
+    "Here we accept the different types of responses from the Agent or API and print the response."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Handle the response appropriately based on streaming mode\n",
+    "if isinstance(response, dict) and \"error\" in response:\n",
+    "    print(f\"\\nError: {response['error']}\")\n",
+    "elif streaming and isinstance(response, dict) and \"completion\" in response:\n",
+    "    print(\"\\n🤖 Agent response (streaming):\")\n",
+    "    if \"extracted_completion\" in response:\n",
+    "        print(response[\"extracted_completion\"])\n",
+    "    else:\n",
+    "        process_streaming_response(response[\"completion\"])\n",
+    "else:\n",
+    "    # Non-streaming response\n",
+    "    print(\"\\n🤖 Agent response:\")\n",
+    "    if isinstance(response, dict) and \"extracted_completion\" in response:\n",
+    "        print(response[\"extracted_completion\"])\n",
+    "    elif (\n",
+    "        isinstance(response, dict) \n",
+    "        and \"completion\" in response\n",
+    "        and hasattr(response[\"completion\"], \"__iter__\")\n",
+    "    ):\n",
+    "        print(\"Processing completion:\")\n",
+    "        full_response = process_streaming_response(response[\"completion\"])\n",
+    "        print(f\"\\nFull response: {full_response}\")\n",
+    "    else:\n",
+    "        print(\"Raw response:\")\n",
+    "        print(f\"{response}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Clean up\n",
+    "Flush telemetry before exiting"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "flush_telemetry()\n",
+    "timer.reset_all()\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "langfuse_obserability",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/evaluation-observe/open-telemetry-instrumentation/trace-bedrock-agents-with-langfuse.ipynb
+++ b/evaluation-observe/open-telemetry-instrumentation/trace-bedrock-agents-with-langfuse.ipynb
@@ -1,0 +1,536 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Amazon Bedrock Recipe: Langfuse Integration with Bedrock Agents\n",
+    "\n",
+    "## Overview\n",
+    "This recipe implements an OpenTelemetry-based tracing and monitoring system for Amazon Bedrock Agents through Langfuse integration. It creates hierarchical trace structures to track agent performance metrics including token usage, latency measurements, and execution durations across preprocessing, orchestration, and postprocessing phases. It processes both streaming and non-streaming responses, generating spans with operation attributes such as timing data, error states, and response content. The error handling and logging functions enable systematic debugging, performance monitoring, and audit trail maintenance. \n",
+    "\n",
+    "### Context\n",
+    "Langfuse integration enables tracing, monitoring, and analyzing the performance and behavior of your Bedrock Agents. This helps in understanding agent interactions, debugging issues, and optimizing performance and can be used with single agents, multi-agent collaboration (MAC), or with inline agents. When using Langfuse you can utilize the cloud platform or a self hosted option on a container. \n",
+    "\n",
+    "#### Use Case\n",
+    "To demonstrate the integration between Langfuse and Amazon Bedrock Agents providing observability outside of AWS tooling. \n",
+    "\n",
+    "#### Implementation\n",
+    "In this notebook we will show how to integrate Amazon Bedrock Agents and Langfuse using both the Langfuse cloud platform and self-hosted option in a container running in AWS. We will configure agent observability, send traces to Langfuse, and validate the results using a single agent.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prerequisites\n",
+    "AWS account with appropriate IAM permissions for Amazon Bedrock Agents and Model Access as well as appropriate permission to deploy containers if using the Langfuse self-hosted option."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Python Dependencies\n",
+    "\n",
+    "To run this notebook, you'll need to install some libraries in your environment:\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "%pip install -r requirements.txt"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### AWS Credentials\n",
+    "Before using Amazon Bedrock, ensure that your AWS credentials are configured correctly. You can set them up using the AWS CLI or by setting environment variables. For this notebook assumes that the credentials are already configured.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import boto3\n",
+    "\n",
+    "# Create the client to invoke Agents in Amazon Bedrock:\n",
+    "br_agents_runtime = boto3.client(\"bedrock-agent-runtime\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Amazon Bedrock Agent\n",
+    "\n",
+    "\n",
+    "We assume you've already created an [Amazon Bedrock Agent](https://docs.aws.amazon.com/bedrock/latest/userguide/agents.html). If you don't have one already you can follow the **[instructions here]()** to set up an example agent.\n",
+    "\n",
+    "Configure your agent's **ID** and (optionally) alias ID in the cell below. You can find these by looking up your agent in the [\"Agents\" page on the AWS Console for Amazon Bedrock](https://console.aws.amazon.com/bedrock/home?#/agents) or CLI.\n",
+    "\n",
+    "The Agent ID should be ten characters, uppercase, and alphanumeric. If you haven't created an Alias for your agent yet, you can use `TSTALIASID` to reference the latest saved development version."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "agent_id = \"\"  # <- Configure your Bedrock Agent ID\n",
+    "agent_alias_id = \"TSTALIASID\"  # <- Optionally set a different Alias ID if you have one"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Before moving on lets validate invoke agent is working correctly. The response is not important we are simply testing the API call. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"Trying to invoke alias {agent_alias_id} of agent {agent_id}...\")\n",
+    "agent_resp = br_agents_runtime.invoke_agent(\n",
+    "    agentAliasId=agent_alias_id,\n",
+    "    agentId=agent_id,\n",
+    "    inputText=\"Hello!\",\n",
+    "    sessionId=\"dummy-session\",\n",
+    ")\n",
+    "if \"completion\" in agent_resp:\n",
+    "    print(\"✅ Got response\")\n",
+    "else:\n",
+    "    raise ValueError(f\"No 'completion' in agent response:\\n{agent_resp}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Langfuse API keys\n",
+    "\n",
+    "There are multiple ways you can use Langfuse - and we'll first need to configure where your Langfuse is hosted:\n",
+    "\n",
+    "### Langfuse Cloud\n",
+    "\n",
+    "If you're directly using [Langfuse Cloud](https://langfuse.com/pricing), your `langfuse_api_url` will be either\n",
+    "- `https://cloud.langfuse.com/`\n",
+    "- `https://us.cloud.langfuse.com/`\n",
+    "- ...or similar.\n",
+    "\n",
+    "### Self-hosted\n",
+    "\n",
+    "If you want to deploy the Open Source version of Langfuse in your own AWS Account, you can use the quick-start [CloudFormation](https://aws.amazon.com/cloudformation/resources/templates/) template provided below:\n",
+    "\n",
+    "> ⚠️ **But first, note:**\n",
+    "> - This sample deployment is intended for initial experimentation, and doesn't fully implement scalability and security best-practices. It should not be used in mission-critical or production environments. For more details, see the [solution source code](https://github.com/aws-samples/amazon-bedrock-samples/tree/main/evaluation-observe/deploy-langfuse-on-ecs-fargate-with-typescript-cdk) and Langfuse's own [documentation on self-hosting](https://langfuse.com/self-hosting).\n",
+    "> - The solution uses resources outside of the AWS Free Tier, and the **estimated cost** to run is around $4-10 per full day (which may vary depending on your usage). When you delete the created stack(s), any data you stored in your Langfuse instance will also be deleted.\n",
+    "> - To deploy this stack, you'll need IAM permissions to manage AWS IAM roles and policies, AWS Lambda Functions, and AWS CodeBuild projects in your account. Find more information about the architecture and deployment [here](https://github.com/aws-samples/amazon-bedrock-samples/tree/main/evaluation-observe/deploy-langfuse-on-ecs-fargate-with-typescript-cdk).\n",
+    "\n",
+    "[![Launch Stack](https://s3.amazonaws.com/cloudformation-examples/cloudformation-launch-stack.png)](https://console.aws.amazon.com/cloudformation/home?#/stacks/create/review?templateURL=https://console.aws.amazon.com/cloudformation/home?#/stacks/create/review?templateURL=https://aws-blogs-artifacts-public.s3.us-east-1.amazonaws.com/artifacts/ML-18524/langfuse-bootstrap.yml&stackName=LangfuseBootstrap \"Launch Stack\")\n",
+    "\n",
+    "Once the stack deploys successfully, look up the `LangfuseUrl` output in the created `LangfuseDemo` stack.\n",
+    "\n",
+    "You'll need to visit this URL to sign up a user account and create an Organization and Project in the Langfuse UI. Take note of the **project name** as you will need that later in the code.\n",
+    "\n",
+    "For your `langfuse_api_url` below, use the same URL `https://123abcdefghijk.cloudfront.net/`.\n",
+    "\n",
+    "\n",
+    "### AWS Marketplace\n",
+    "\n",
+    "For production-ready deployments of Langfuse on your own AWS Account, check out the [offerings from Langfuse on the AWS Marketplace](https://aws.amazon.com/marketplace/seller-profile?id=seller-nmyz7ju7oafxu).\n",
+    "\n",
+    "---\n",
+    "\n",
+    "However your Langfuse environment is deployed, set up the target URL below:\n",
+    "\n",
+    "> ⚠️ **Note:** If you change this URL after using it, you'll need to **restart your notebook kernel**. Otherwise, you'll see a message like `opentelemetry.trace - WARNING - Overriding of current TracerProvider is not allowed` when you try to use the new one, and the client won't work correctly."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "langfuse_api_url = \"https://us.cloud.langfuse.com/\"  # <- Replace as described above"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Once your Langfuse environment is set up and you've signed in to the UI, you'll need to set up an **API key pair** for your particular Organization and Project (create a new project if you don't have one already).\n",
+    "\n",
+    "For more information, see the [FAQ: Where are my Langfuse API keys](https://langfuse.com/faq/all/where-are-langfuse-api-keys) and Langfuse's [getting started documentation](https://langfuse.com/docs/get-started)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "langfuse_public_key = \"xxx\"  # <- Configure your own key here\n",
+    "langfuse_secret_key = \"xxx\"  # <- Configure your own key here"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Setting up agent tracing\n",
+    "\n",
+    "With all the pre-requisites in place, we're ready to recording traces from your Bedrock Agent into Langfuse.\n",
+    "\n",
+    "First, let's load the libraries:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import time\n",
+    "import boto3\n",
+    "import uuid\n",
+    "import json\n",
+    "from core.timer_lib import timer\n",
+    "from core import instrument_agent_invocation, flush_telemetry"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Now lets define a wrapper function\n",
+    "Here we create a wrapper function that is used to Invoke the Amazon Bedrock Agent with instrumentation for Langfuse on the Amazon Bedrock Agents runtime API.\n",
+    "\n",
+    "1. Instrumentation for monitoring\n",
+    "2. Configurable streaming support\n",
+    "3. Trace enabling for debugging\n",
+    "4. Flexible parameter handling through kwargs\n",
+    "5. Proper logging of configuration states\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@instrument_agent_invocation\n",
+    "def invoke_bedrock_agent(\n",
+    "    inputText: str, agentId: str, agentAliasId: str, sessionId: str, **kwargs\n",
+    "):\n",
+    "    \"\"\"Invoke a Bedrock Agent with instrumentation for Langfuse.\"\"\"\n",
+    "    # Create Bedrock client\n",
+    "    bedrock_rt_client = boto3.client(\"bedrock-agent-runtime\")\n",
+    "    use_streaming = kwargs.get(\"streaming\", False)\n",
+    "    invoke_params = {\n",
+    "        \"inputText\": inputText,\n",
+    "        \"agentId\": agentId,\n",
+    "        \"agentAliasId\": agentAliasId,\n",
+    "        \"sessionId\": sessionId,\n",
+    "        \"enableTrace\": True,  # Required for instrumentation\n",
+    "    }\n",
+    "\n",
+    "    # Add streaming configurations if needed\n",
+    "    if use_streaming:\n",
+    "        invoke_params[\"streamingConfigurations\"] = {\n",
+    "            \"applyGuardrailInterval\": 10,\n",
+    "            \"streamFinalResponse\": True,\n",
+    "        }\n",
+    "    response = bedrock_rt_client.invoke_agent(**invoke_params)\n",
+    "    return response"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Now lets create a wrapper function to handle the responses\n",
+    "\n",
+    "1. Instrumentation for monitoring\n",
+    "2. Configurable streaming support\n",
+    "3. Trace enabling for debugging\n",
+    "4. Flexible parameter handling through kwargs\n",
+    "5. Proper logging of configuration states\n",
+    "\n",
+    "It's particularly useful for:\n",
+    "\n",
+    "1. Real-time processing of large responses\n",
+    "2. Interactive applications requiring immediate feedback\n",
+    "3. Debugging and monitoring streaming responses\n",
+    "4. Ensuring proper text encoding/decoding"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def process_streaming_response(stream):\n",
+    "    \"\"\"Process a streaming response from Bedrock Agent.\"\"\"\n",
+    "    full_response = \"\"\n",
+    "    try:\n",
+    "        for event in stream:\n",
+    "            # Convert event to dictionary if it's a botocore Event object\n",
+    "            event_dict = (\n",
+    "                event.to_response_dict()\n",
+    "                if hasattr(event, \"to_response_dict\")\n",
+    "                else event\n",
+    "            )\n",
+    "            if \"chunk\" in event_dict:\n",
+    "                chunk_data = event_dict[\"chunk\"]\n",
+    "                if \"bytes\" in chunk_data:\n",
+    "                    output_bytes = chunk_data[\"bytes\"]\n",
+    "                    # Convert bytes to string if needed\n",
+    "                    if isinstance(output_bytes, bytes):\n",
+    "                        output_text = output_bytes.decode(\"utf-8\")\n",
+    "                    else:\n",
+    "                        output_text = str(output_bytes)\n",
+    "                    full_response += output_text\n",
+    "    except Exception as e:\n",
+    "        print(f\"\\nError processing stream: {e}\")\n",
+    "    return full_response"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Langfuse Configuration"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import base64\n",
+    "start = time.time()\n",
+    "with open('config.json', 'r') as config_file:\n",
+    "    config = json.load(config_file)\n",
+    "    \n",
+    " # For Langfuse specifically but you can add any other observability provider:\n",
+    "os.environ[\"OTEL_SERVICE_NAME\"] = 'Langfuse'\n",
+    "os.environ[\"DEPLOYMENT_ENVIRONMENT\"] = config[\"langfuse\"][\"environment\"]\n",
+    "project_name = config[\"langfuse\"][\"project_name\"]\n",
+    "environment = config[\"langfuse\"][\"environment\"]\n",
+    "langfuse_public_key = config[\"langfuse\"][\"langfuse_public_key\"]\n",
+    "langfuse_secret_key = config[\"langfuse\"][\"langfuse_secret_key\"]\n",
+    "langfuse_api_url = config[\"langfuse\"][\"langfuse_api_url\"]\n",
+    "\n",
+    "# Create auth header\n",
+    "auth_token = base64.b64encode(\n",
+    "    f\"{langfuse_public_key}:{langfuse_secret_key}\".encode()\n",
+    ").decode()\n",
+    "\n",
+    "# Set OpenTelemetry environment variables for Langfuse\n",
+    "os.environ[\"OTEL_EXPORTER_OTLP_ENDPOINT\"] = f\"{langfuse_api_url}/api/public/otel/v1/traces\"\n",
+    "os.environ[\"OTEL_EXPORTER_OTLP_HEADERS\"] = f\"Authorization=Basic {auth_token}\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Update fields to pass to Agent and User \n",
+    "The next code block will require some editing before running. Here we will set parameters used by Langfuse to track traces\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "# Langfuse configuration\n",
+    "project_name = \"xxx\" #Enter your Langfuse Project name that you created \n",
+    "environment = \"default\"  #Enter the env name\n",
+    "\n",
+    "# User information\n",
+    "user_id = \"xxx\" #This will be used in the Langfuse UI to filter traces\n",
+    "\n",
+    "# Foundation Model used by the agent (used to estimate costs)\n",
+    "agent_model_id = \"xxx\"  #eg \"claude-3-5-sonnet-20241022-v2:0\"\n",
+    "    "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Agent configuration\n",
+    "agentId = config[\"agent\"][\"agentId\"]\n",
+    "agentAliasId = config[\"agent\"][\"agentAliasId\"]\n",
+    "sessionId = f\"session-{int(time.time())}\"\n",
+    "\n",
+    "# User information\n",
+    "userId = config[\"user\"][\"userId\"]  \n",
+    "agent_model_id = config[\"user\"][\"agent_model_id\"]\n",
+    "\n",
+    "# Tags for filtering in Langfuse\n",
+    "tags = [\"bedrock-agent\", \"example\", \"development\"]\n",
+    "\n",
+    "# Generate a custom trace ID\n",
+    "trace_id = str(uuid.uuid4())\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Prompt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Your prompt and streaming mode\n",
+    "question = \"xxx\" # your prompt to the agent\n",
+    "streaming = False\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Invoke Agent Function\n",
+    "There we pass all the parameters Invoking the agent along with the observability integration with Langfuse."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Single invocation that works for both streaming and non-streaming\n",
+    "response = invoke_bedrock_agent(\n",
+    "    inputText=question,\n",
+    "    agentId=agentId,\n",
+    "    agentAliasId=agentAliasId,\n",
+    "    sessionId=sessionId,\n",
+    "    show_traces=True,\n",
+    "    SAVE_TRACE_LOGS=True,\n",
+    "    userId=userId,\n",
+    "    tags=tags,\n",
+    "    trace_id=trace_id,\n",
+    "    project_name=project_name,\n",
+    "    environment=environment,\n",
+    "    langfuse_public_key=langfuse_public_key,\n",
+    "    langfuse_secret_key=langfuse_secret_key,\n",
+    "    langfuse_api_url=langfuse_api_url,\n",
+    "    streaming=streaming,\n",
+    "    model_id=agent_model_id,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Response Handling\n",
+    "Here we accept the different types of responses from the Agent or API and print the response."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Handle the response appropriately based on streaming mode\n",
+    "if isinstance(response, dict) and \"error\" in response:\n",
+    "    print(f\"\\nError: {response['error']}\")\n",
+    "elif streaming and isinstance(response, dict) and \"completion\" in response:\n",
+    "    print(\"\\n🤖 Agent response (streaming):\")\n",
+    "    if \"extracted_completion\" in response:\n",
+    "        print(response[\"extracted_completion\"])\n",
+    "    else:\n",
+    "        process_streaming_response(response[\"completion\"])\n",
+    "else:\n",
+    "    # Non-streaming response\n",
+    "    print(\"\\n🤖 Agent response:\")\n",
+    "    if isinstance(response, dict) and \"extracted_completion\" in response:\n",
+    "        print(response[\"extracted_completion\"])\n",
+    "    elif (\n",
+    "        isinstance(response, dict) \n",
+    "        and \"completion\" in response\n",
+    "        and hasattr(response[\"completion\"], \"__iter__\")\n",
+    "    ):\n",
+    "        print(\"Processing completion:\")\n",
+    "        full_response = process_streaming_response(response[\"completion\"])\n",
+    "        print(f\"\\nFull response: {full_response}\")\n",
+    "    else:\n",
+    "        print(\"Raw response:\")\n",
+    "        print(f\"{response}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Clean up\n",
+    "Flush telemetry before exiting"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "flush_telemetry()\n",
+    "timer.reset_all()\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "langfuse_obserability",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Created jupyter notebook from existing main.py to walk users through code execution with explanations. Notebook allows users to store their API keys and Agent Aliases/IDs and a custom prompt to run. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
