### PR TITLE
bda workshop - use haiku 3.5 for reasoning in us-west-2

### DIFF
--- a/data-automation-bda/workshops/05-rag/02_multi_modal_data_query_with_kb.ipynb
+++ b/data-automation-bda/workshops/05-rag/02_multi_modal_data_query_with_kb.ipynb
@@ -407,7 +407,7 @@
    "outputs": [],
    "source": [
     "foundation_model = \"anthropic.claude-3-5-haiku-20241022-v1:0\"\n",
-    "foundation_model = \"amazon.nova-micro-v1:0\"\n",
+    "#foundation_model = \"amazon.nova-micro-v1:0\"\n",
     "\n",
     "response = bedrock_agent_runtime_client.retrieve_and_generate(\n",
     "    input={\n",


### PR DESCRIPTION
*Issue #, if available:*
Hot fix: Claude Sonnet 3 is no longer available in newly provisioned workshop accounts. Please use Haiku 3.5 instead.

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
