### PR TITLE
feat(langfuse): Add Cognito authentication support

### DIFF
--- a/evaluation-observe/deploy-langfuse-on-ecs-fargate-with-typescript-cdk/.gitignore
+++ b/evaluation-observe/deploy-langfuse-on-ecs-fargate-with-typescript-cdk/.gitignore
@@ -42,5 +42,6 @@ Thumbs.db
 dist
 cdk.out
 .cdk.staging
+cdk.context.json
 
 config.py

--- a/evaluation-observe/deploy-langfuse-on-ecs-fargate-with-typescript-cdk/README.md
+++ b/evaluation-observe/deploy-langfuse-on-ecs-fargate-with-typescript-cdk/README.md
@@ -4,6 +4,7 @@ Langfuse is an Open Source LLM Engineering platform that helps teams collaborati
 
 This repository demonstrates how to deploy a self-hosted Langfuse solution using AWS Fargate for Amazon ECS. It is designed for initial experimentation and is not suitable for production use. Additionally, it does not include all capabilities available in the Langfuse Enterprise Edition. For production-ready deployments, check out the [Langfuse offerings through AWS Marketplace](https://aws.amazon.com/marketplace/seller-profile?id=seller-nmyz7ju7oafxu).
 
+
 ## Architecture overview
 
 This deployment involves multiple AWS services to host Langfuse components as described in their [official documentation on self-hosting](https://langfuse.com/self-hosting#architecture). In this sample, shown also in the architecture diagram below, we use:
@@ -36,11 +37,25 @@ This deployment involves multiple AWS services to host Langfuse components as de
 
 This flow ensures efficient handling of requests while leveraging AWS's managed services for scalability, reliability, and security.
 
+
 ## Deployment option 1: Quick start
 
 If you don't have CDK development tooling set up already, and would just like to deploy the Langfuse architecture with the default settings - you can use the [AWS CloudFormation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/Welcome.html) template in [cfn_bootstrap.yml](./cfn_bootstrap.yml): Open the [CloudFormation Console](https://console.aws.amazon.com/cloudformation/home?#/stacks/create) in your target AWS Account and Region, click **Create stack**, and upload the template file.
 
 This "bootstrap" stack sets up a CI project in [AWS CodeBuild](https://docs.aws.amazon.com/codebuild/latest/userguide/welcome.html) which pulls the sample code and performs the below app CDK setup steps for you automatically in the Cloud - with no local development environment required. ⚠️ **Note** though, that the CodeBuild project is granted *broad permissions* to deploy all the sample's AWS resources on your behalf - so is not recommended for use in production environments as-is.
+
+
+## After deployment: Getting started
+
+You can find the URL to access your Langfuse UI from the `LangfuseUrl` "Output" of your stack in [CloudFormation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/Welcome.html).
+
+If you deployed with the default, recommended configuration (see [bin/demo.ts](bin/demo.ts)) using Amazon Cognito for authentication, you'll need to head on over to your created user pool in the [Amazon Cognito User Pools console](https://console.aws.amazon.com/cognito/v2/idp/user-pools) to set yourself up a username and password for logging in to Langfuse.
+
+If you *disabled* Cognito during deployment, you can simply "Sign up" from your Langfuse URL.
+
+> ⚠️ **Warning:** Allowing public open sign-up is not recommended! you could also consider re-deploying the `LangfuseDemo` construct with `langfuseEnvironment: {'AUTH_DISABLE_SIGNUP': 'true'}` to disable it, after creating your first admin user.
+
+
 
 ## Deployment option 2: Developer setup (Suggested workflow)
 

--- a/evaluation-observe/deploy-langfuse-on-ecs-fargate-with-typescript-cdk/bin/demo.ts
+++ b/evaluation-observe/deploy-langfuse-on-ecs-fargate-with-typescript-cdk/bin/demo.ts
@@ -5,16 +5,22 @@ import { LangfuseDemoStack } from "../lib/stack";
 
 const app = new cdk.App();
 new LangfuseDemoStack(app, "LangfuseDemo", {
-  /* If you don't specify 'env', this stack will be environment-agnostic.
-   * Account/Region-dependent features and context lookups will not work,
-   * but a single synthesized template can be deployed anywhere. */
-  /* Uncomment the next line to specialize this stack for the AWS Account
-   * and Region that are implied by the current CLI configuration. */
-  // env: { account: process.env.CDK_DEFAULT_ACCOUNT, region: process.env.CDK_DEFAULT_REGION },
-  /* Uncomment the next line if you know exactly what Account and Region you
-   * want to deploy the stack to. */
+  // This stack cannot be synthesized as environment-agnostic (skipping `env`) when
+  // `useCognitoAuth` is `true`, because it needs to create a unique domain prefix for Cognito and
+  // uses the target Account ID and Region to do this.
+  // Here we use the settings implied by the current CLI configuration:
+  env: {
+    account: process.env.CDK_DEFAULT_ACCOUNT,
+    region: process.env.CDK_DEFAULT_REGION,
+  },
+  // Alternatively, uncomment the next line if you know exactly what Account and Region you
+  // want to deploy the stack to:
   // env: { account: '123456789012', region: 'us-east-1' },
   /* For more information, see https://docs.aws.amazon.com/cdk/latest/guide/environments.html */
+
+  // Env var is expected to be 'cognito' or 'langfuse' - with cognito as the default:
+  useCognitoAuth:
+    (process.env.LANGFUSE_AUTH_TYPE || "cognito").toLowerCase() == "cognito",
 });
 
 cdk.Aspects.of(app).add(new AwsSolutionsChecks());

--- a/evaluation-observe/deploy-langfuse-on-ecs-fargate-with-typescript-cdk/cdk.context.json
+++ b/evaluation-observe/deploy-langfuse-on-ecs-fargate-with-typescript-cdk/cdk.context.json
@@ -1,5 +1,0 @@
-{
-  "acknowledged-issue-numbers": [
-    null
-  ]
-}

--- a/evaluation-observe/deploy-langfuse-on-ecs-fargate-with-typescript-cdk/cfn_bootstrap.yml
+++ b/evaluation-observe/deploy-langfuse-on-ecs-fargate-with-typescript-cdk/cfn_bootstrap.yml
@@ -11,6 +11,16 @@ Description: |-
   Grants broad permissions to CodeBuild - not recommended for use in production environments.
 
 Parameters:
+  AuthType:
+    Type: String
+    AllowedValues:
+      - 'cognito'
+      - 'langfuse'
+    Default: 'cognito'
+    Description: >-
+      We recommend 'cognito' to manage your Langfuse users through Amazon Cognito. The 'langfuse'
+      native auth will have public user sign-up enabled by default through the web UI!
+
   CodeRepo:
     Type: String
     Default: https://github.com/aws-samples/amazon-bedrock-samples
@@ -34,6 +44,10 @@ Parameters:
 Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
+      - Label:
+          default: Solution Settings
+        Parameters:
+          - AuthType
       - Label:
           default: Source Code Location
         Parameters:
@@ -143,6 +157,9 @@ Resources:
         ComputeType: BUILD_GENERAL1_LARGE
         EnvironmentVariables:
           # Pass CFn stack parameters through to the deploy job:
+          - Name: LANGFUSE_AUTH_TYPE
+            Type: PLAINTEXT
+            Value: !Ref AuthType
           - Name: PUBLIC_REPO
             Type: PLAINTEXT
             Value: !Ref CodeRepo

--- a/evaluation-observe/deploy-langfuse-on-ecs-fargate-with-typescript-cdk/lib/langfuse/cognito.ts
+++ b/evaluation-observe/deploy-langfuse-on-ecs-fargate-with-typescript-cdk/lib/langfuse/cognito.ts
@@ -1,101 +1,243 @@
-import * as cdk from "aws-cdk-lib";
-import * as cognito from 'aws-cdk-lib/aws-cognito';
-import { Construct } from "constructs";
-import { NagSuppressions } from "cdk-nag";
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+// NodeJS Built-Ins:
+import * as crypto from "crypto";
 
+// External Dependencies:
+import * as cdk from "aws-cdk-lib";
+import * as cognito from "aws-cdk-lib/aws-cognito";
+import * as secretsmanager from "aws-cdk-lib/aws-secretsmanager";
+import { NagSuppressions } from "cdk-nag";
+import { Construct } from "constructs";
 
 /**
- * Interface for configuring Cognito authentication
- * @interface ICognitoProps
- * @property {string} loadBalancerUrl - The URL of the load balancer for callback/logout URLs
- * @property {string} [userPoolId] - Optional existing Cognito User Pool ID to use instead of creating new one
- * @property {boolean} [createDomain] - Whether to create a Cognito domain, defaults to false
- * @property {string} [userPoolDomainPrefix] - Prefix for the Cognito domain if createDomain is true
+ * Convenience construct for setting up a simple Cognito user pool and domain
+ *
+ * This is intended for basic setup only and does not enforce full best-practices for security with
+ * Cognito. You probably don't want to add configuration props to this - but use the underlying
+ * UserPool and UserPoolDomain constructs directly instead.
  */
-export interface ICognitoProps {
-    loadBalancerUrl: string;
-    userPoolId?: string;
-    createDomain?: boolean;
-    userPoolDomainPrefix?: string;
-    createSecret?: boolean;
-    /**
-     * @default true
-     */
+export class BasicCognitoUserPoolWithDomain extends Construct {
+  /**
+   * Secret containing 'clientId', 'clientSecret', and 'issuer' values for your app
+   */
+  public readonly userPool: cognito.UserPool;
+  /**
+   * URL to access your Cognito User Pool's domain.
+   */
+  public readonly cognitoDomainUrl: string;
+
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+
+    this.userPool = new cognito.UserPool(this, "UserPool", {
+      accountRecovery: cognito.AccountRecovery.EMAIL_ONLY,
+      autoVerify: {
+        email: true,
+      },
+      passwordPolicy: {
+        minLength: 8,
+        requireLowercase: true,
+        requireUppercase: true,
+        requireDigits: true,
+        requireSymbols: true,
+      },
+      selfSignUpEnabled: false,
+      signInAliases: {
+        email: true,
+        username: true,
+      },
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+    });
+    NagSuppressions.addResourceSuppressions(this.userPool, [
+      { id: "AwsSolutions-COG2", reason: "MFA is not required for this demo" },
+    ]);
+    NagSuppressions.addResourceSuppressions(this.userPool, [
+      {
+        id: "AwsSolutions-COG3",
+        reason: "AdvancedSecurityMode is not required for this demo",
+      },
+    ]);
+
+    const domain = new cognito.UserPoolDomain(this, "Domain", {
+      userPool: this.userPool,
+      cognitoDomain: {
+        domainPrefix: generateUniqueDomainName(this, {
+          prefix: "langfuse-demo",
+        }),
+      },
+    });
+    this.cognitoDomainUrl = domain.baseUrl();
+  }
 }
 
+export interface ILangfuseCognitoClientOptions {
+  /**
+   * Base URL of your Langfuse deployment - e.g. 'https://...cloudfront.net'
+   */
+  readonly baseUrl: string;
+  /**
+   * Customize the OAuth scopes that are allowed to be shared with this client
+   * @default '[aws_cognito.OAuthScope.EMAIL, aws_cognito.OAuthScope.PROFILE]'
+   */
+  readonly scopes?: cognito.OAuthScope[];
+}
 
-export class CognitoAuth extends Construct {
-    public readonly cognitoSecret: cdk.aws_secretsmanager.Secret;
+/**
+ * Add a 'client' to a Cognito user pool, configured for use with Langfuse
+ */
+export function addLangfuseCognitoClient(
+  userPool: cognito.UserPool,
+  id: string,
+  options: ILangfuseCognitoClientOptions,
+): cognito.UserPoolClient {
+  return userPool.addClient(id, {
+    generateSecret: true,
+    oAuth: {
+      callbackUrls: [options.baseUrl.concat("/api/auth/callback/cognito")],
+      logoutUrls: [options.baseUrl.concat("/auth/sign-in")],
+      scopes: options.scopes || [
+        cognito.OAuthScope.EMAIL,
+        cognito.OAuthScope.PROFILE,
+      ],
+      flows: {
+        authorizationCodeGrant: true,
+        implicitCodeGrant: true,
+      },
+    },
+    supportedIdentityProviders: [
+      cognito.UserPoolClientIdentityProvider.COGNITO,
+    ],
+  });
+}
 
-    constructor(scope: Construct, id: string, props: ICognitoProps) {
-        super(scope, id);
+export interface ICognitoOAuthSecretProps {
+  /**
+   * Cognito user pool which must have been created with with `userPoolClientSecret` prop set true
+   */
+  userPool: cognito.IUserPool;
+  /**
+   * Cognito user pool 'client' for this application to connect as
+   */
+  client: cognito.IUserPoolClient;
+}
 
-        const userPool = props.userPoolId
-            ? cognito.UserPool.fromUserPoolId(this, 'UserPool', props.userPoolId)
-            : new cognito.UserPool(this, 'UserPool', {
-                selfSignUpEnabled: false,
-                signInAliases: {
-                    email: true, username: true
-                },
-                autoVerify: {
-                    email: true,
-                },
-                passwordPolicy: {
-                    minLength: 8,
-                    requireLowercase: true,
-                    requireUppercase: true,
-                    requireDigits: true,
-                    requireSymbols: true,
-                },
-                removalPolicy: cdk.RemovalPolicy.DESTROY,
-                accountRecovery: cognito.AccountRecovery.EMAIL_ONLY
-            });
-
-        const domain = props.createDomain
-            ? new cognito.UserPoolDomain(this, 'UserPoolDomain', {
-                userPool,
-                cognitoDomain: { domainPrefix: props.userPoolDomainPrefix || 'langfuse-demo' }
-            }) : {};
-
-        NagSuppressions.addResourceSuppressions(userPool, [
-            { id: 'AwsSolutions-COG2', reason: 'MFA is not required for this demo' },
-        ]);
-        NagSuppressions.addResourceSuppressions(userPool, [
-            { id: 'AwsSolutions-COG3', reason: 'AdvancedSecurityMode is not required for this demo' },
-        ]);
-
-
-        const userPoolClient = userPool.addClient('UserPoolClient', {
-            userPoolClientName: 'LangfuseWebApp',
-            generateSecret: true,
-            oAuth: {
-                callbackUrls: [props.loadBalancerUrl.concat('/api/auth/callback/cognito')],
-                logoutUrls: [props.loadBalancerUrl.concat('/auth/sign-in')],
-                scopes: [
-                    cognito.OAuthScope.EMAIL,
-                    cognito.OAuthScope.PROFILE,
-                ],
-                flows: {
-                    authorizationCodeGrant: true,
-                    implicitCodeGrant: true,
-                },
-            },
-            supportedIdentityProviders: [
-                cognito.UserPoolClientIdentityProvider.COGNITO,
-            ],
-        })
-
-        this.cognitoSecret = new cdk.aws_secretsmanager.Secret(this, 'CognitoSecret', {
-            secretObjectValue: {
-                AUTH_COGNITO_CLIENT_ID: cdk.SecretValue.unsafePlainText(userPoolClient.userPoolClientId),
-                AUTH_COGNITO_CLIENT_SECRET: userPoolClient.userPoolClientSecret,
-                AUTH_COGNITO_ISSUER: cdk.SecretValue.unsafePlainText(`https://cognito-idp.${cdk.Aws.REGION}.amazonaws.com/${userPool.userPoolId}`)
-            },
-            secretName: 'CognitoSecret',
-        });
-        NagSuppressions.addResourceSuppressions(this.cognitoSecret, [
-            { id: 'AwsSolutions-SMG4', reason: 'Secret rotation is not required for this demo' },
-        ]);
+/**
+ * Construct for a secret with 'clientId', 'clientSecret', and 'issuer' from Cognito
+ *
+ * This secret includes the necessary attributes for an application to perform OAuth with Cognito
+ */
+export class CognitoOAuthSecret extends secretsmanager.Secret {
+  constructor(scope: Construct, id: string, props: ICognitoOAuthSecretProps) {
+    if (!props.client.userPoolClientSecret) {
+      throw new Error(
+        "Cognito client must be created with 'generateSecret' set to true",
+      );
     }
 
+    super(scope, id, {
+      secretObjectValue: {
+        // Only the userPoolClientSecret actually needs to be "secret", so the unsafePlainTexts
+        // here shouldn't be an issue:
+        clientId: cdk.SecretValue.unsafePlainText(
+          props.client.userPoolClientId,
+        ),
+        clientSecret: props.client.userPoolClientSecret,
+        issuer: cdk.SecretValue.unsafePlainText(
+          `https://cognito-idp.${cdk.Aws.REGION}.amazonaws.com/${props.userPool.userPoolId}`,
+        ),
+      },
+    });
+    NagSuppressions.addResourceSuppressions(this, [
+      {
+        id: "AwsSolutions-SMG4",
+        reason: "Secret rotation is not required for this demo",
+      },
+    ]);
+  }
+}
+
+/**
+ * Generate a globally-unique but repeatable domain prefix dependent on deployment context
+ *
+ * This method uses logic inspired by CDK's generatePhysicalName, which is a private method so we
+ * can't use that API directly. We also tweak it a little to support passing a user-specified
+ * prefix, and allocating remaining character budget depending how long that prefix is.
+ *
+ * Most of the function is generic, but the default maxLength is tuned for Cognito domains.
+ *
+ * @see https://github.com/aws/aws-cdk/blob/main/packages/aws-cdk-lib/core/lib/private/physical-name-generator.ts
+ */
+export function generateUniqueDomainName(
+  scope: Construct,
+  config: {
+    maxLength?: number;
+    prefix?: string;
+  },
+): string {
+  const prefix = config.prefix || "";
+  // Max length of a Cognito domain prefix is 63 per:
+  // https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_CreateUserPoolDomain.html#CognitoUserPools-CreateUserPoolDomain-request-Domain
+  // However, in practice we see validation errors whenever the *overall domain* exceeds
+  // this limit - meaning we only have about 24-27 (depending on the region name)
+  const maxLength = config.maxLength || 24;
+
+  let nFreeChars = maxLength - prefix.length;
+  if (nFreeChars < 0) {
+    throw new Error(
+      `Prefix '${prefix}' is longer than the maximum length ${maxLength}`,
+    );
+  }
+
+  const stack = cdk.Stack.of(scope);
+  const nodeUniqueId = cdk.Names.nodeUniqueId(scope.node);
+
+  let region: string = stack.region;
+  if (cdk.Token.isUnresolved(region) || !region) {
+    throw new Error(
+      `Cannot generate a unique ID for ${scope.node.path}, because the region is un-resolved or missing`,
+    );
+  }
+
+  const account: string = stack.account;
+  if (cdk.Token.isUnresolved(account) || !account) {
+    throw new Error(
+      `Cannot generate a unique ID for ${scope.node.path}, because the account is un-resolved or missing`,
+    );
+  }
+
+  const unknownStackName = cdk.Token.isUnresolved(stack.stackName);
+  const sha256 = crypto
+    .createHash("sha256")
+    .update(prefix)
+    .update(nodeUniqueId)
+    .update(region)
+    .update(account);
+
+  if (!unknownStackName) sha256.update(stack.stackName);
+
+  let maxHashLen: number;
+  if (nFreeChars <= 8) {
+    maxHashLen = nFreeChars;
+  } else {
+    maxHashLen = Math.floor(6 + (nFreeChars - 6) / 3);
+  }
+  const hashPart = sha256.digest("hex").slice(0, maxHashLen);
+  nFreeChars -= hashPart.length;
+
+  let maxIdPartLen: number;
+  if (nFreeChars <= 4 || unknownStackName) {
+    maxIdPartLen = nFreeChars;
+  } else {
+    maxIdPartLen = Math.floor(2 + (nFreeChars - 2) / 2);
+  }
+  // Need the condition because .slice(-0) returns whole string:
+  const idPart = maxIdPartLen ? nodeUniqueId.slice(-maxIdPartLen) : "";
+  nFreeChars -= idPart.length;
+
+  const stackPart = unknownStackName
+    ? ""
+    : stack.stackName.slice(0, nFreeChars);
+  const ret = [prefix, stackPart, idPart, hashPart].join("");
+  return ret.toLowerCase();
 }

--- a/evaluation-observe/deploy-langfuse-on-ecs-fargate-with-typescript-cdk/lib/langfuse/cognito.ts
+++ b/evaluation-observe/deploy-langfuse-on-ecs-fargate-with-typescript-cdk/lib/langfuse/cognito.ts
@@ -1,0 +1,101 @@
+import * as cdk from "aws-cdk-lib";
+import * as cognito from 'aws-cdk-lib/aws-cognito';
+import { Construct } from "constructs";
+import { NagSuppressions } from "cdk-nag";
+
+
+/**
+ * Interface for configuring Cognito authentication
+ * @interface ICognitoProps
+ * @property {string} loadBalancerUrl - The URL of the load balancer for callback/logout URLs
+ * @property {string} [userPoolId] - Optional existing Cognito User Pool ID to use instead of creating new one
+ * @property {boolean} [createDomain] - Whether to create a Cognito domain, defaults to false
+ * @property {string} [userPoolDomainPrefix] - Prefix for the Cognito domain if createDomain is true
+ */
+export interface ICognitoProps {
+    loadBalancerUrl: string;
+    userPoolId?: string;
+    createDomain?: boolean;
+    userPoolDomainPrefix?: string;
+    createSecret?: boolean;
+    /**
+     * @default true
+     */
+}
+
+
+export class CognitoAuth extends Construct {
+    public readonly cognitoSecret: cdk.aws_secretsmanager.Secret;
+
+    constructor(scope: Construct, id: string, props: ICognitoProps) {
+        super(scope, id);
+
+        const userPool = props.userPoolId
+            ? cognito.UserPool.fromUserPoolId(this, 'UserPool', props.userPoolId)
+            : new cognito.UserPool(this, 'UserPool', {
+                selfSignUpEnabled: false,
+                signInAliases: {
+                    email: true, username: true
+                },
+                autoVerify: {
+                    email: true,
+                },
+                passwordPolicy: {
+                    minLength: 8,
+                    requireLowercase: true,
+                    requireUppercase: true,
+                    requireDigits: true,
+                    requireSymbols: true,
+                },
+                removalPolicy: cdk.RemovalPolicy.DESTROY,
+                accountRecovery: cognito.AccountRecovery.EMAIL_ONLY
+            });
+
+        const domain = props.createDomain
+            ? new cognito.UserPoolDomain(this, 'UserPoolDomain', {
+                userPool,
+                cognitoDomain: { domainPrefix: props.userPoolDomainPrefix || 'langfuse-demo' }
+            }) : {};
+
+        NagSuppressions.addResourceSuppressions(userPool, [
+            { id: 'AwsSolutions-COG2', reason: 'MFA is not required for this demo' },
+        ]);
+        NagSuppressions.addResourceSuppressions(userPool, [
+            { id: 'AwsSolutions-COG3', reason: 'AdvancedSecurityMode is not required for this demo' },
+        ]);
+
+
+        const userPoolClient = userPool.addClient('UserPoolClient', {
+            userPoolClientName: 'LangfuseWebApp',
+            generateSecret: true,
+            oAuth: {
+                callbackUrls: [props.loadBalancerUrl.concat('/api/auth/callback/cognito')],
+                logoutUrls: [props.loadBalancerUrl.concat('/auth/sign-in')],
+                scopes: [
+                    cognito.OAuthScope.EMAIL,
+                    cognito.OAuthScope.PROFILE,
+                ],
+                flows: {
+                    authorizationCodeGrant: true,
+                    implicitCodeGrant: true,
+                },
+            },
+            supportedIdentityProviders: [
+                cognito.UserPoolClientIdentityProvider.COGNITO,
+            ],
+        })
+
+        this.cognitoSecret = new cdk.aws_secretsmanager.Secret(this, 'CognitoSecret', {
+            secretObjectValue: {
+                AUTH_COGNITO_CLIENT_ID: cdk.SecretValue.unsafePlainText(userPoolClient.userPoolClientId),
+                AUTH_COGNITO_CLIENT_SECRET: userPoolClient.userPoolClientSecret,
+                AUTH_COGNITO_ISSUER: cdk.SecretValue.unsafePlainText(`https://cognito-idp.${cdk.Aws.REGION}.amazonaws.com/${userPool.userPoolId}`)
+            },
+            secretName: 'CognitoSecret',
+        });
+        NagSuppressions.addResourceSuppressions(this.cognitoSecret, [
+            { id: 'AwsSolutions-SMG4', reason: 'Secret rotation is not required for this demo' },
+        ]);
+    }
+
+}

--- a/evaluation-observe/deploy-langfuse-on-ecs-fargate-with-typescript-cdk/lib/langfuse/service-base.ts
+++ b/evaluation-observe/deploy-langfuse-on-ecs-fargate-with-typescript-cdk/lib/langfuse/service-base.ts
@@ -286,6 +286,7 @@ export class LangfuseServiceBase extends Construct {
       ...(props.environment || {}),
     };
     if (props.s3BatchExportPrefix) {
+      taskEnv.LANGFUSE_S3_BATCH_EXPORT_BUCKET = props.s3Bucket.bucketName;
       taskEnv.LANGFUSE_S3_BATCH_EXPORT_PREFIX = props.s3BatchExportPrefix;
       taskEnv.LANGFUSE_S3_BATCH_EXPORT_REGION = cdk.Stack.of(this).region;
     }

--- a/evaluation-observe/deploy-langfuse-on-ecs-fargate-with-typescript-cdk/lib/langfuse/web.ts
+++ b/evaluation-observe/deploy-langfuse-on-ecs-fargate-with-typescript-cdk/lib/langfuse/web.ts
@@ -34,16 +34,21 @@ interface ILangfuseWebServiceProps extends ILangfuseServiceSharedProps {
    */
   nextAuthSecret: secretsmanager.ISecret;
   /**
+   * Optional Secrets Manager Secret storing Cognito authentication parameters
+   *
+   * Providing this parameter will set up Langfuse environment variables to use Cognito and disable
+   * open user sign-up. The secret should be a key-value format containing at least
+   * `clientId`, `clientSecret`, and `issuer` fields.
+   *
+   * @default None
+   */
+  authCognitoSecret?: secretsmanager.ISecret;
+  /**
    * Source container image name for the worker
    *
    * @default 'langfuse/langfuse'
    */
   imageName?: string;
-
-  /**
-   * In case of Cognito authentication
-   */
-  authCognitoSecret?: secretsmanager.ISecret
 }
 
 /**
@@ -58,9 +63,9 @@ export class LangfuseWebService extends LangfuseServiceBase {
           ? props.loadBalancer.url
           : `http://0.0.0.0:${LANGFUSE_WEB_PORT}`,
         ...(props.authCognitoSecret && {
-          AUTH_DISABLE_SIGNUP: 'false',
-          AUTH_COGNITO_ALLOW_ACCOUNT_LINKING: 'true',
-          AUTH_DISABLE_USERNAME_PASSWORD: 'true'
+          AUTH_COGNITO_ALLOW_ACCOUNT_LINKING: "true",
+          AUTH_DISABLE_SIGNUP: "false",
+          AUTH_DISABLE_USERNAME_PASSWORD: "true",
         }),
         ...(props.environment || {}),
       },
@@ -87,15 +92,28 @@ export class LangfuseWebService extends LangfuseServiceBase {
       secrets: {
         NEXTAUTH_SECRET: ecs.Secret.fromSecretsManager(props.nextAuthSecret),
         ...(props.authCognitoSecret && {
-          AUTH_COGNITO_CLIENT_ID: ecs.Secret.fromSecretsManager(props.authCognitoSecret, 'AUTH_COGNITO_CLIENT_ID'),
-          AUTH_COGNITO_CLIENT_SECRET: ecs.Secret.fromSecretsManager(props.authCognitoSecret, 'AUTH_COGNITO_CLIENT_SECRET'),
-          AUTH_COGNITO_ISSUER: ecs.Secret.fromSecretsManager(props.authCognitoSecret, 'AUTH_COGNITO_ISSUER')
-        })
+          AUTH_COGNITO_CLIENT_ID: ecs.Secret.fromSecretsManager(
+            props.authCognitoSecret,
+            "clientId",
+          ),
+          AUTH_COGNITO_CLIENT_SECRET: ecs.Secret.fromSecretsManager(
+            props.authCognitoSecret,
+            "clientSecret",
+          ),
+          AUTH_COGNITO_ISSUER: ecs.Secret.fromSecretsManager(
+            props.authCognitoSecret,
+            "issuer",
+          ),
+        }),
       },
       serviceName: "web",
     });
 
-    const sec = ecs.Secret.fromSecretsManager(props.nextAuthSecret)
+    if (props.authCognitoSecret)
+      props.authCognitoSecret.grantRead(
+        this.fargateService.taskDefinition.taskRole,
+      );
+
     const securityGroup = new ec2.SecurityGroup(this, "WebSG", {
       vpc: props.vpc,
       allowAllOutbound: false,

--- a/evaluation-observe/deploy-langfuse-on-ecs-fargate-with-typescript-cdk/lib/stack.ts
+++ b/evaluation-observe/deploy-langfuse-on-ecs-fargate-with-typescript-cdk/lib/stack.ts
@@ -1,19 +1,52 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+// External Dependencies:
 import * as cdk from "aws-cdk-lib";
 import { Construct } from "constructs";
 
 // Local Dependencies:
 import { LangfuseDeployment, LangfuseVpcInfra } from "./langfuse";
+import { BasicCognitoUserPoolWithDomain } from "./langfuse/cognito";
 
+export interface ILangfuseDemoStackProps extends cdk.StackProps {
+  /**
+   * Set `true` to create and use Amazon Cognito User Pool for authentication
+   *
+   * @default - Langfuse native auth will be used - ⚠️ with open sign-up!
+   */
+  useCognitoAuth?: boolean;
+}
+
+/**
+ * A basic deployment of the Langfuse construct pattern for demos
+ */
 export class LangfuseDemoStack extends cdk.Stack {
-  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+  constructor(
+    scope: Construct,
+    id: string,
+    props: ILangfuseDemoStackProps = {},
+  ) {
     super(scope, id, props);
 
     const tags = [new cdk.Tag("project", "langfuse-demo")];
 
     const vpcInfra = new LangfuseVpcInfra(this, "VpcInfra", { tags });
 
+    let cognitoUserPool;
+    if (props.useCognitoAuth) {
+      cognitoUserPool = new BasicCognitoUserPoolWithDomain(
+        this,
+        "LangfuseCognito",
+      ).userPool;
+      // Also output the pool ID to help admins identify the correct one in console:
+      new cdk.CfnOutput(this, "CognitoUserPoolId", {
+        value: cognitoUserPool.userPoolId,
+      });
+    }
+
     // The code that defines your stack goes here
     const langfuse = new LangfuseDeployment(this, "Langfuse", {
+      cognitoUserPool,
       tags,
       vpc: vpcInfra.vpc,
     });


### PR DESCRIPTION
- Add new cognito.ts file implementing CognitoAuth construct for user authentication
- Update main.ts to integrate Cognito authentication with Langfuse deployment
- Modify web.ts to configure Langfuse web service with Cognito authentication options
- Enable disabling username/password login when using Cognito
- Add support for optional existing User Pool ID and domain configuration