### PR TITLE
Delete action bedrock:UseInferenceProfile which does not actually exist

### DIFF
--- a/agents-and-function-calling/bedrock-agents/features-examples/01-create-agent-with-function-definition/01-create-agent-with-function-definition.ipynb
+++ b/agents-and-function-calling/bedrock-agents/features-examples/01-create-agent-with-function-definition/01-create-agent-with-function-definition.ipynb
@@ -559,7 +559,6 @@
     "            \"Action\":  [\n",
     "                \"bedrock:GetInferenceProfile\",\n",
     "                \"bedrock:ListInferenceProfiles\",\n",
-    "                \"bedrock:UseInferenceProfile\"\n",
     "            ],\n",
     "            \"Resource\": [\n",
     "                f\"arn:aws:bedrock:*:*:inference-profile/{inference_profile}\"\n",


### PR DESCRIPTION
Action is not listed in https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazonbedrock.html and it is flagged as an error in IAM Policy Editor

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
