### PR TITLE
(langfuse-deploy) CloudFormation bootstrap improvements & fixes

### DIFF
--- a/evaluation-observe/deploy-langfuse-on-ecs-fargate-with-typescript-cdk/.gitignore
+++ b/evaluation-observe/deploy-langfuse-on-ecs-fargate-with-typescript-cdk/.gitignore
@@ -43,5 +43,6 @@ dist
 cdk.out
 .cdk.staging
 cdk.context.json
+cdk.outputs.json
 
 config.py

--- a/evaluation-observe/deploy-langfuse-on-ecs-fargate-with-typescript-cdk/cdk.json
+++ b/evaluation-observe/deploy-langfuse-on-ecs-fargate-with-typescript-cdk/cdk.json
@@ -1,5 +1,6 @@
 {
   "app": "npx ts-node --prefer-ts-exts bin/demo.ts",
+  "outputsFile": "cdk.outputs.json",
   "watch": {
     "include": [
       "**"

--- a/evaluation-observe/deploy-langfuse-on-ecs-fargate-with-typescript-cdk/cfn_bootstrap.yml
+++ b/evaluation-observe/deploy-langfuse-on-ecs-fargate-with-typescript-cdk/cfn_bootstrap.yml
@@ -233,17 +233,45 @@ Resources:
                   import os
                   import requests  # (You'll need to install this!)
                   resp_url = os.environ.get("CFN_EVENT_RESPONSE_URL")
+
+                  def flatten(d, parent_key="", sep="."):
+                      """Flatten nested JSON dicts (basic, doesn't touch arrays)
+
+                      CFn allows us to return complex attribute data types, but doesn't have good
+                      ways to reference nested fields in the template - so best for us to flatten.
+                      This way e.g. `!GetAtt MyDeployment.StackName.MyStackOutput` will work.
+                      """
+                      items = []
+                      for key, value in d.items():
+                          new_key = sep.join((parent_key, key)) if parent_key else key
+                          if isinstance(value, dict):
+                              items.extend(flatten(value, new_key, sep=sep).items())
+                          else:
+                              items.append((new_key, value))
+                      return dict(items)
+
                   if not resp_url:
                       print("No CloudFormation response URL provided")
                       exit(0)
                   try:
                       data = json.loads(os.environ["CFN_EVENT_DATA"])
-                      data["Status"] = "SUCCESS" if int(os.environ["CODEBUILD_BUILD_SUCCEEDING"]) else "FAILED"
+                      if int(os.environ["CODEBUILD_BUILD_SUCCEEDING"]):
+                          data["Status"] = "SUCCESS"
+                          try:
+                              # Pass CDK deploy outputs as attributes of this CFn resource:
+                              with open("cdk.outputs.json") as fouts:
+                                  outputs = json.load(fouts)
+                                  data["Data"] = flatten(outputs)
+                          except FileNotFoundError:
+                              print(
+                                  "No cdk.outputs.json found: Have your deploy job create this "
+                                  "file if you want to pass outputs back to the bootstrap stack."
+                              )
+                      else:
+                          data["Status"] = "FAILED"
                       build_arn = os.environ["CODEBUILD_BUILD_ARN"]
-                      data["PhysicalResourceId"] = build_arn
-                      log_stream = f"/aws/codebuild/{build_arn.partition('/')[2]}"
-                      data["Reason"] = "See details in " + (
-                          f"CloudWatch Log Stream {log_stream}" if log_stream else f"AWS CodeBuild {build_arn}"
+                      data["Reason"] = "See details in CloudWatch Log Stream /aws/codebuild/" + (
+                          build_arn.partition("/")[2]
                       )
                       response = requests.put(resp_url, data=json.dumps(data))
                       print(f"Notified CloudFormation of {data['Status']}")
@@ -351,7 +379,8 @@ Resources:
                           event,
                           context,
                           cfnresponse.FAILED,
-                          { "Reason": f"Unsupported CFN RequestType '{request_type}'" },
+                          {},
+                          reason=f"Unsupported CFN RequestType '{request_type}'",
                       )
               except Exception as e:
                   logging.error("Uncaught exception in CFN custom resource handler - reporting failure")
@@ -360,7 +389,8 @@ Resources:
                       event,
                       context,
                       cfnresponse.FAILED,
-                      { "Reason": str(e) },
+                      {},
+                      reason=f"See CloudWatch {context.log_group_name} > {context.log_stream_name} - {str(e)}",
                   )
                   raise e
 
@@ -377,6 +407,7 @@ Resources:
                           "type": "PLAINTEXT",
                           "value": json.dumps({
                               "LogicalResourceId": event["LogicalResourceId"],
+                              "PhysicalResourceId": event["LogicalResourceId"],
                               "RequestId": event["RequestId"],
                               "StackId": event["StackId"],
                               "NoEcho": event["ResourceProperties"].get("NoEcho", False),
@@ -406,7 +437,11 @@ Resources:
                       context,
                       cfnresponse.SUCCESS,
                       { "Reason": f"Started CodeBuild #{result['build']['buildNumber']}" },
-                      physicalResourceId=result["build"]["arn"],
+                      # Changing physical ID would look like a 'replacement' to CloudFormation,
+                      # causing it to send a delete/CDK destroy request to the old physical ID
+                      # after running CDK deploy on the new one - which is pretty much never what
+                      # we want.
+                      physicalResourceId=event["LogicalResourceId"],
                   )
 
           def handle_delete(event, context):
@@ -462,6 +497,10 @@ Resources:
       Runtime: python3.10
       Timeout: 900
 
+  # IF you enable CodeBuildCallback AND your deployment script creates 'cdk.outputs.json', the
+  # contents should be passed through as output attributes on this CFn resource to use how you want
+  # For example, re-exposing them as outputs of this CFn bootstrap stack) with a reference like:
+  #     !GetAtt SampleDeployment.MyStackName.SomeOutput
   SampleDeployment:
     Type: "Custom::CodeBuildTrigger"
     Properties:
@@ -470,8 +509,8 @@ Resources:
       BuildOnDelete: true
       # NOTE: If CDK deployment takes longer than 1 hour, this CodeBuild-based callback to
       # CloudFormation *will not work* because CFn will time out. In that case can comment out /
-      # unset `CodeBuildCallback`, and the ATTP stack will "succeed" as soon as the CodeBuild job
-      # is triggered, without waiting for it to complete.
+      # unset `CodeBuildCallback`, and the bootstrap stack will "succeed" as soon as the CodeBuild
+      # job is triggered, without waiting for it to complete.
       CodeBuildCallback: true
 
 Outputs:
@@ -484,3 +523,6 @@ Outputs:
   CodeBuildConsoleLink:
     Description: Link to project in AWS CodeBuild Console
     Value: !Sub "https://${AWS::Region}.console.aws.amazon.com/codesuite/codebuild/${AWS::AccountId}/projects/${CodeBuildProject}"
+  LangfuseUrl:
+    Description: Link to deployed Langfuse service
+    Value: !GetAtt SampleDeployment.LangfuseDemo.LangfuseUrl


### PR DESCRIPTION
**Issue #, if available:** N/A

**Description of changes:**

1. (For the [GenAIOps with Langfuse workshop](https://catalog.workshops.aws/genaiops-langfuse)) Add a mechanism to pass outputs from CDK-deployed stacks back in to the bootstrap CloudFormation stack, which allows us to surface the deployed `LangfuseUrl` to workshop participants more easily without them needing to go trawl through the CFn console
2. Fix issue where SampleDeployment returning new `PhysicalResourceId` after updates caused CloudFormation to treat the update as a replacement and subsequently raise a `DELETE` request for the old physical ID... Which runs a `cdk destroy` and deleted the deployment 🤦‍♂️
3. Per the [cfnresponse docs](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-lambda-function-code-cfnresponsemodule.html), a deployment failure `Reason` needs to be passed through the `reason` kwarg - not in the data object as we were trying to do. Fixed this to help clarify deployment failure reason messages when things go wrong.

<br/>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
