### PR TITLE
Fixed a bug in Amazon Bedrock Agents Workshop Lab 4

### DIFF
--- a/agents-and-function-calling/bedrock-agents/features-examples/04-create-agent-with-single-knowledge-base/04-create-agent-with-single-knowledge-base.ipynb
+++ b/agents-and-function-calling/bedrock-agents/features-examples/04-create-agent-with-single-knowledge-base/04-create-agent-with-single-knowledge-base.ipynb
@@ -808,7 +808,7 @@
     "}\n",
     "\n",
     "# Create index\n",
-    "response = open_search_client.indices.create(kb_vector_index_name, body=index_body)\n",
+    "response = open_search_client.indices.create(index=kb_vector_index_name, body=index_body)\n",
     "print('\\nCreating index:')\n",
     "print(response)"
    ]


### PR DESCRIPTION
Last week, I delivered the [Amazon Bedrock Agents Workshop](https://catalog.workshops.aws/agents-for-amazon-bedrock/en-US) to a group of customers and identified a bug in [Lab 4 - Create Agent with a Single Knowledge Base](https://catalog.workshops.aws/agents-for-amazon-bedrock/en-US/40-create-agent-with-single-knowledge-base).

### Issue

```python
response = open_search_client.indices.create(kb_vector_index_name, body=index_body)
```

<img width="1076" height="394" alt="bug" src="https://github.com/user-attachments/assets/e2ba80db-002b-47a7-b37a-b455546cf8e9" />

### Fix

```python
response = open_search_client.indices.create(index=kb_vector_index_name, body=index_body)
```

<img width="1087" height="188" alt="fix" src="https://github.com/user-attachments/assets/75a9a0ef-0b6f-4276-879c-53c14d496f7d" />

