### PR TITLE
fix: Langfuse ENCRYPTION_KEY containing invalid hex

### DIFF
--- a/evaluation-observe/deploy-langfuse-on-ecs-fargate-with-typescript-cdk/lib/langfuse/main.ts
+++ b/evaluation-observe/deploy-langfuse-on-ecs-fargate-with-typescript-cdk/lib/langfuse/main.ts
@@ -273,7 +273,7 @@ export class LangfuseDeployment extends Construct {
         description:
           "Langfuse ENCRYPTION_KEY (Used to encrypt sensitive data. Must be 256 bits, 64 string characters in hex format)",
         generateSecretString: {
-          excludeCharacters: "ghijklmnopqrstuvxyz",
+          excludeCharacters: "ghijklmnopqrstuvwxyz",
           excludePunctuation: true,
           includeSpace: false,
           excludeUppercase: true,


### PR DESCRIPTION
*Issue #, if available:* Related issue in the langfuse repo https://github.com/langfuse/langfuse/issues/8037

*Description of changes:* The character w was missing, which would then cause an invalid ENCRYPTION_KEY to be generated as it would no longer be hex. This causes issues in langfuse such as not being able to create a defualt llmApiKey.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
