### PR TITLE
Fixed code bug in creating agent with KB example

### DIFF
--- a/agents-and-function-calling/bedrock-agents/features-examples/04-create-agent-with-single-knowledge-base/04-create-agent-with-single-knowledge-base.ipynb
+++ b/agents-and-function-calling/bedrock-agents/features-examples/04-create-agent-with-single-knowledge-base/04-create-agent-with-single-knowledge-base.ipynb
@@ -808,7 +808,7 @@
     "}\n",
     "\n",
     "# Create index\n",
-    "response = open_search_client.indices.create(kb_vector_index_name, body=index_body)\n",
+    "response = open_search_client.indices.create(index=kb_vector_index_name, body=index_body)\n",
     "print('\\nCreating index:')\n",
     "print(response)"
    ]


### PR DESCRIPTION
*Issue #, if available:*

When attempting to create OpenSearch index the code kept failing on the command open_search_client.indices.create() due to parameter issues. 

*Description of changes:*

The create() method expects the index name as a keyword argument, not a positional argument. The code shared in the notebook is incorrect and kept returning the following error whenever executed :


```
TypeError                                 Traceback (most recent call last)
Cell In[31], line 52
     47 index_body["mappings"]["properties"][kb_metadataField] = {
     48     "type": "text"
     49 }
     51 # Create index
---> 52 response = open_search_client.indices.create(kb_vector_index_name, body=index_body)
     53 print('\nCreating index:')
     54 print(response)

File /opt/conda/lib/python3.12/site-packages/opensearchpy/client/utils.py:176, in query_params.<locals>._wrapper.<locals>._wrapped(*args, **kwargs)
    173         if v is not None:
    174             params[p] = _escape(v)
—> 176 return func(*args, params=params, headers=headers, **kwargs)

TypeError: IndicesClient.create() takes 1 positional argument but 2 positional arguments (and 3 keyword-only arguments) were given
```



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
