### PR TITLE
clarify batch orchestration

### DIFF
--- a/poc-to-prod/bedrock-batch-orchestrator/README.md
+++ b/poc-to-prod/bedrock-batch-orchestrator/README.md
@@ -134,7 +134,7 @@ To generate embeddings with a model like Titan-V2 embeddings, you do not need to
 
 ![Step Function Execution](static/step-function-console.png)
 
-Monitor your step function as it runs the job(s). **The max number of concurrent jobs is controlled by a CDK context variable in [`cdk.json`](cdk.json) (key: `maxConcurrentJobs`)**. The paths to your resulting CSV file(s) will be aggregated in the outputs from the execution.
+Monitor your step function as it runs the job(s). **The max number of submitted and in-progress jobs is controlled by a CDK context variable in [`cdk.json`](cdk.json) (key: `maxSubmittedAndInProgressJobs`)**. The paths to your resulting CSV file(s) will be aggregated in the outputs from the execution.
 
 The output CSV file(s) will contain all the same columns as your input file.
 

--- a/poc-to-prod/bedrock-batch-orchestrator/cdk.json
+++ b/poc-to-prod/bedrock-batch-orchestrator/cdk.json
@@ -17,7 +17,7 @@
     ]
   },
   "context": {
-    "bedrockBatchInferenceMaxConcurrency": 20,
+    "maxSubmittedAndInProgressJobs": 20,
     "bedrockBatchInferenceTimeoutHours": 24,
     "@aws-cdk/aws-lambda:recognizeLayerVersion": true,
     "@aws-cdk/core:checkSecretUsage": true,

--- a/poc-to-prod/bedrock-batch-orchestrator/lib/bedrock-batch-orchestrator-stack.ts
+++ b/poc-to-prod/bedrock-batch-orchestrator/lib/bedrock-batch-orchestrator-stack.ts
@@ -14,7 +14,7 @@ import * as targets from 'aws-cdk-lib/aws-events-targets';
 
 
 export interface BedrockBatchOrchestratorStackProps extends cdk.StackProps {
-  bedrockBatchInferenceMaxConcurrency: number;
+  maxSubmittedAndInProgressJobs: number;
   bedrockBatchInferenceTimeoutHours?: number;
 }
 
@@ -156,7 +156,7 @@ export class BedrockBatchOrchestratorStack extends cdk.Stack {
     });
 
     const postprocessMap = new sfn.Map(this, 'postprocessMap', {
-      maxConcurrency: props.bedrockBatchInferenceMaxConcurrency,
+      maxConcurrency: props.maxSubmittedAndInProgressJobs,
       itemsPath: sfn.JsonPath.stringAt('$.completed_jobs'),
       resultPath: '$.output_paths',
     });
@@ -168,7 +168,7 @@ export class BedrockBatchOrchestratorStack extends cdk.Stack {
 
     // step function
     const batchProcessingMap = new sfn.Map(this, 'batchProcessingMap', {
-      maxConcurrency: props.bedrockBatchInferenceMaxConcurrency,
+      maxConcurrency: props.maxSubmittedAndInProgressJobs,
       itemsPath: sfn.JsonPath.stringAt('$.jobs'),
       resultPath: '$.completed_jobs',
     });


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Changes the name of the key that controls the depth of the step function map for Bedrock Batch Inference from `bedrockBatchInferenceMaxConcurrency` to `maxSubmittedAndInProgressJobs` to clarify its meaning.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
