### PR TITLE
fix: Ensure key generation uses only valid hex characters

### DIFF
--- a/evaluation-observe/deploy-langfuse-on-ecs-fargate-with-typescript-cdk/lib/langfuse/main.ts
+++ b/evaluation-observe/deploy-langfuse-on-ecs-fargate-with-typescript-cdk/lib/langfuse/main.ts
@@ -305,7 +305,7 @@ export class LangfuseDeployment extends Construct {
         description:
           "Langfuse ENCRYPTION_KEY (Used to encrypt sensitive data. Must be 256 bits, 64 string characters in hex format)",
         generateSecretString: {
-          excludeCharacters: "ghijklmnopqrstuvxyz",
+          excludeCharacters: "ghijklmnopqrstuvwxyz",
           excludePunctuation: true,
           includeSpace: false,
           excludeUppercase: true,


### PR DESCRIPTION
The encryption key was incorrectly allowing the character 'w' in its output, which is not a valid hexadecimal character.

*Description of changes:*
The generated encryption key for Langfuse may be invalid since it should also exclude the character `w` as it's not a valid HEX character. Keys generated with a `w` wouldn't be usable for encryption.

[Here's the line in Langfuse that encrypts secrets using that encryption key](https://github.com/langfuse/langfuse/blob/7598c95fc3c962e387d398f88e27329466d95780/packages/shared/src/encryption/encryption.ts#L23)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
