### PR TITLE
docs: fix typos in 03_combining_project_blueprints_with_multipage_documents.ipynb

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository contains pre-built examples to help customers get started with t
 ## Contents
 
 - [Introduction to Bedrock](introduction-to-bedrock) - Learn the basics of the Bedrock service
-- [Prompt Engineering ](articles-guides) - Tips for crafting effective prompts 
+- [Prompt Engineering ](articles-guides/README.md) - Tips for crafting effective prompts 
 - [Agents](agents-and-function-calling) - Ways to implement Generative AI Agents and its components.
 - [Custom Model Import](custom-models) - Import custom models into Bedrock
 - [Multimodal](multi-modal) - Working with multimodal data using Amazon Bedrock

--- a/articles-guides/README.md
+++ b/articles-guides/README.md
@@ -4,18 +4,18 @@ This repository contains pre-built examples to help customers get started with t
 
 ## Contents
 
-- [Introduction to Bedrock](introduction-to-bedrock) - Learn the basics of the Bedrock service
+- [Introduction to Bedrock](../introduction-to-bedrock) - Learn the basics of the Bedrock service
 - [Prompt Engineering ](prompt-engineering) - Tips for crafting effective prompts 
-- [Bedrock Fine-tuning](bedrock-fine-tuning) - Fine-tune Bedrock models for your specific use case
-- [Custom Model Import](custom-models) - Import custom models into Bedrock
-- [Generative AI Solutions](generative-ai-solutions) - Example use cases for generative AI
-- [Knowledge Bases](knowledge-bases) - Build knowledge bases with Bedrock
-- [Retrival Augmented Generation (RAG)](rag-solutions) - Implementing RAG with Amazon Bedrock
-- [Agents](agents-for-bedrock) - Generative AI agents with Bedrock
-- [Security and Governance](security-and-governance) - Secure your Bedrock applications
-- [Responsible AI](responsible-ai) - Use Bedrock responsibly and ethically
-- [Operational Tooling](ops-tooling) - Helpful samples to help operationalize your useage of Amazon Bedrock
-- [Multimodal](multimodal) - Working with multimodal data using Amazon Bedrock
+- [Bedrock Fine-tuning](../model-latency-benchmarking) - Fine-tune Bedrock models for your specific use case
+- [Custom Model Import](../custom-models) - Import custom models into Bedrock
+- [Generative AI Solutions](../genai-use-cases) - Example use cases for generative AI
+- [Knowledge Bases](../rag) - Build knowledge bases with Bedrock
+- [Retrival Augmented Generation (RAG)](../rag) - Implementing RAG with Amazon Bedrock
+- [Agents](../agents-and-function-calling) - Generative AI agents with Bedrock
+- [Security and Governance](../security) - Secure your Bedrock applications
+- [Responsible AI](../responsible_ai) - Use Bedrock responsibly and ethically
+- [Operational Tooling](../evaluation-observe) - Helpful samples to help operationalize your useage of Amazon Bedrock
+- [Multimodal](../multi-modal) - Working with multimodal data using Amazon Bedrock
 
 ## Getting Started
 

--- a/data-automation-bda/workshops/01-document/03_combining_project_blueprints_with_multipage_documents.ipynb
+++ b/data-automation-bda/workshops/01-document/03_combining_project_blueprints_with_multipage_documents.ipynb
@@ -581,7 +581,7 @@
    "metadata": {},
    "source": [
     "### View Job Metadata\n",
-    "Let's retrieve the job metadata. The Job metadata contains the S3 uri's for the standard output,custom output and the status of custom output. The custom output status could be either of `MATCH` or `NO_MATCH`. `MATCH` indicates BDA was able to find a matching blueprint for the specific segment from the list of blueprint we associated with the project. If BDA was unable to match the segment to a blueprint associated with the project then the `custom output status` is `NO_MATCH` and in this case BDA would only have a standard output extracted from that specific segment of the input file."
+    "Let's retrieve the job metadata. The Job metadata contains the S3 uri's for the standard output, custom output and the status of custom output. The custom output status could be either of `MATCH` or `NO_MATCH`. `MATCH` indicates BDA was able to find a matching blueprint for the specific segment from the list of blueprint we associated with the project. If BDA was unable to match the segment to a blueprint associated with the project then the `custom output status` is `NO_MATCH` and in this case BDA would only have a standard output extracted from that specific segment of the input file."
    ]
   },
   {


### PR DESCRIPTION
Fixes #522. Corrected typos: 'chan' to 'can' and added missing space in 'output, custom'.