### PR TITLE
fix: update product-review-agent dataset URL to canonical UCSD lab domain

### DIFF
--- a/agents-and-function-calling/bedrock-agents/use-case-examples/product-review-agent/README.md
+++ b/agents-and-function-calling/bedrock-agents/use-case-examples/product-review-agent/README.md
@@ -8,7 +8,7 @@ The agent integrates with the knowledge base **without an explicit association**
 
 ## Dataset
 
-This example uses the [amazon reviews 2018 dataset](https://jmcauley.ucsd.edu/data/amazon_v2/categoryFilesSmall/All_Beauty_5.json.gz) with these fields - review (string), rating (number), timestamp (number), reviewers (string list).
+This example uses the [amazon reviews 2018 dataset](https://mcauleylab.ucsd.edu/public_datasets/data/amazon_v2/categoryFilesSmall/All_Beauty_5.json.gz) with these fields - review (string), rating (number), timestamp (number), reviewers (string list).
 
 We create the following metadata file for each of the text chunks (review) in the knowledge base.
 

--- a/agents-and-function-calling/bedrock-agents/use-case-examples/product-review-agent/main.ipynb
+++ b/agents-and-function-calling/bedrock-agents/use-case-examples/product-review-agent/main.ipynb
@@ -171,7 +171,7 @@
    },
    "outputs": [],
    "source": [
-    "!curl -o 'data/All_Beauty_5.json.gz' 'https://jmcauley.ucsd.edu/data/amazon_v2/categoryFilesSmall/All_Beauty_5.json.gz' --insecure"
+    "!curl -o 'data/All_Beauty_5.json.gz' 'https://mcauleylab.ucsd.edu/public_datasets/data/amazon_v2/categoryFilesSmall/All_Beauty_5.json.gz' --insecure"
    ]
   },
   {

--- a/docs/agents-and-function-calling/bedrock-agents/use-case-examples/product-review-agent/main.md
+++ b/docs/agents-and-function-calling/bedrock-agents/use-case-examples/product-review-agent/main.md
@@ -107,7 +107,7 @@ except:
 
 
 ```python
-!curl -o 'data/All_Beauty_5.json.gz' 'https://jmcauley.ucsd.edu/data/amazon_v2/categoryFilesSmall/All_Beauty_5.json.gz' --insecure
+!curl -o 'data/All_Beauty_5.json.gz' 'https://mcauleylab.ucsd.edu/public_datasets/data/amazon_v2/categoryFilesSmall/All_Beauty_5.json.gz' --insecure
 ```
 
 


### PR DESCRIPTION
## Summary

Updates the Amazon reviews dataset URL in `product-review-agent` from the legacy personal domain `jmcauley.ucsd.edu` to Prof. McAuley's canonical lab domain `mcauleylab.ucsd.edu`.

## Context

Issue #542 reported the old URL as broken. As of today the old URL still returns 200 OK with valid gzip data, but Prof. McAuley's canonical website now points users to the lab domain (`mcauleylab.ucsd.edu`) for dataset access. Updating to the canonical URL:

- Matches the replacement URL the reporter identified via Prof. McAuley's homepage
- Reduces risk of future breakage when the legacy personal domain is eventually decommissioned
- Aligns with the source cited in UCSD's lab publications

## Files changed

- `agents-and-function-calling/bedrock-agents/use-case-examples/product-review-agent/main.ipynb`
- `agents-and-function-calling/bedrock-agents/use-case-examples/product-review-agent/README.md`
- `docs/agents-and-function-calling/bedrock-agents/use-case-examples/product-review-agent/main.md`

## Verification

- New URL returns `HTTP 200`, Content-Type `application/x-gzip`, 633507 bytes — same dataset file (`All_Beauty_5.json.gz`) as the legacy URL.
- Notebook JSON validated after edit.

Fixes #542