### PR TITLE
fix: add missing space in BDA blueprints notebook (issue #522)

### DIFF
--- a/data-automation-bda/workshops/01-document/03_combining_project_blueprints_with_multipage_documents.ipynb
+++ b/data-automation-bda/workshops/01-document/03_combining_project_blueprints_with_multipage_documents.ipynb
@@ -581,7 +581,7 @@
    "metadata": {},
    "source": [
     "### View Job Metadata\n",
-    "Let's retrieve the job metadata. The Job metadata contains the S3 uri's for the standard output,custom output and the status of custom output. The custom output status could be either of `MATCH` or `NO_MATCH`. `MATCH` indicates BDA was able to find a matching blueprint for the specific segment from the list of blueprint we associated with the project. If BDA was unable to match the segment to a blueprint associated with the project then the `custom output status` is `NO_MATCH` and in this case BDA would only have a standard output extracted from that specific segment of the input file."
+    "Let's retrieve the job metadata. The Job metadata contains the S3 uri's for the standard output, custom output and the status of custom output. The custom output status could be either of `MATCH` or `NO_MATCH`. `MATCH` indicates BDA was able to find a matching blueprint for the specific segment from the list of blueprint we associated with the project. If BDA was unable to match the segment to a blueprint associated with the project then the `custom output status` is `NO_MATCH` and in this case BDA would only have a standard output extracted from that specific segment of the input file."
    ]
   },
   {


### PR DESCRIPTION
## Summary

Adds missing space after the comma in `"standard output,custom output"` → `"standard output, custom output"` in the **View Job Metadata** section of `03_combining_project_blueprints_with_multipage_documents.ipynb`.

## Context

Issue #522 reported two typos:
- `"chan have"` → already fixed upstream (current file reads `"can have"`)
- `"output,custom"` missing space → fixed by this PR

## Verification

- Notebook JSON validated after edit
- Single-line change, minimal diff

Fixes #522