### PR TITLE
Update lounge access demo: model ID and workshop branding

### DIFF
--- a/responsible_ai/bedrock-automated-reasoning-checks/lounge_access_agent_demo/demo.py
+++ b/responsible_ai/bedrock-automated-reasoning-checks/lounge_access_agent_demo/demo.py
@@ -23,7 +23,7 @@ from policy_engine import create_test_scenarios
 GUARDRAIL_ID = os.getenv("GUARDRAIL_ID")
 GUARDRAIL_VERSION = os.getenv("GUARDRAIL_VERSION", "DRAFT")
 KNOWLEDGE_BASE_ID = os.getenv("KNOWLEDGE_BASE_ID")
-MODEL_ID = os.getenv("MODEL_ID", "us.anthropic.claude-sonnet-4-20250514-v1:0")
+MODEL_ID = os.getenv("MODEL_ID", "us.anthropic.claude-sonnet-4-6")
 AWS_DEFAULT_REGION = os.getenv("AWS_DEFAULT_REGION")
 
 # Get the current region
@@ -49,7 +49,7 @@ if 'conversation_history' not in st.session_state:
 
 def main():
     st.title("🛫 Airport Lounge Access Agent with Automated Reasoning")
-    st.markdown("### AWS re:Invent 2025 Workshop Demo")
+    st.markdown("### AWS Automated Reasoning Workshop Demo")
     
     # Sidebar for navigation and configuration
     with st.sidebar:

--- a/responsible_ai/bedrock-automated-reasoning-checks/lounge_access_agent_demo/launch-demo-app.ipynb
+++ b/responsible_ai/bedrock-automated-reasoning-checks/lounge_access_agent_demo/launch-demo-app.ipynb
@@ -83,8 +83,7 @@
     "# Get the URL for the app\n",
     "import sage_maker_utils\n",
     "\n",
-    "url_response = sage_maker_utils.get_streamlit_url()\n",
-    "print(f\"Demo App URL: {url_response}\")"
+    "url_response = sage_maker_utils.get_streamlit_url()"
    ]
   },
   {

--- a/responsible_ai/bedrock-automated-reasoning-checks/lounge_access_agent_demo/lounge-access-agent.ipynb
+++ b/responsible_ai/bedrock-automated-reasoning-checks/lounge_access_agent_demo/lounge-access-agent.ipynb
@@ -74,7 +74,7 @@
     "KB_ID = \"<KNOWLEDGE_BASE_ID>\"                               # Replace with your Knowledge Base ID\n",
     "GUARDRAIL_ID = \"<GUARDRAIL_ID>\"                             # Replace with your Guardrail ID\n",
     "GUARDRAIL_VERSION = \"<GUARDRAIL_VERSION>\"                   # Replace with your Guardrail Version if different from the default\n",
-    "MODEL_ID = \"us.anthropic.claude-sonnet-4-20250514-v1:0\"     # Replace with another model if you choose to do so"
+    "MODEL_ID = \"us.anthropic.claude-sonnet-4-6\"                 # Replace with another model if you choose to do so"
    ]
   },
   {


### PR DESCRIPTION
- Update model ID from claude-sonnet-4-20250514-v1:0 to claude-sonnet-4-6
- Rename workshop title from 're:Invent 2025' to generic branding
- Remove redundant print statement in launch notebook

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
